### PR TITLE
Allow passing custom protocol to language server

### DIFF
--- a/pygls/server.py
+++ b/pygls/server.py
@@ -194,11 +194,13 @@ class LanguageServer(Server):
     registered commands/features.
 
     Args:
+        protocol_cls(LanguageServerProtocol): LSP or any subclass of it
         max_workers(int, optional): Number of workers for `ThreadPool` and
                                     `ThreadPoolExecutor`
     """
 
-    def __init__(self, loop=None, max_workers: int = 2):
+    def __init__(self, loop=None, protocol_cls=LanguageServerProtocol, max_workers: int = 2):
+        assert issubclass(protocol_cls, LanguageServerProtocol)
         super().__init__(LanguageServerProtocol, loop, max_workers)
 
     def apply_edit(self, edit: WorkspaceEdit, label: str = None) -> ApplyWorkspaceEditResponse:
@@ -225,7 +227,8 @@ class LanguageServer(Server):
         """
         return self.lsp.fm.feature(feature_name, **options)
 
-    def get_configuration(self, params: ConfigurationParams, callback: ConfigCallbackType = None) -> Future:
+    def get_configuration(self, params: ConfigurationParams,
+                          callback: ConfigCallbackType = None) -> Future:
         """Gets the configuration settings from the client."""
         return self.lsp.get_configuration(params, callback)
 

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -35,7 +35,7 @@ NumType = Union[int, float]
 
 
 class ApplyWorkspaceEditParams:
-    def __init__(self, edit: 'WorkspaceEditCapability', label: Optional[str]):
+    def __init__(self, edit: 'WorkspaceEdit', label: Optional[str] = None):
         self.edit = edit
         self.label = label
 


### PR DESCRIPTION
Allow passing custom _language server protocol_ to server instance.

Changed constructor parameter type for class [ApplyWorkspaceEditParams](https://github.com/openlawlibrary/pygls/blob/master/pygls/types.py#L37).