### PR TITLE
Fix possibly non existing parameter

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 
 - [@augb](https://github.com/augb)
 - [Daniel Elero](https://github.com/danixeee)
+- [yorodm](https://github.com/yorodm)

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -510,8 +510,10 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         client_capabilities = params.capabilities
         root_uri = params.rootUri
         root_path = params.rootPath
-        workspace_folders = params.workspaceFolders or []
-
+        try:
+            workspace_folders = params.workspaceFolders or []
+        except AttributeError:
+            workspace_folders = []
         if root_uri is None:
             root_uri = from_fs_path(root_path) if root_path is not None else ''
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -44,6 +44,7 @@ from .types import (ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse,
                     ServerCapabilities, ShowMessageParams, WorkspaceEdit)
 from .uris import from_fs_path
 from .workspace import Workspace
+from .uris import to_fs_path
 
 logger = logging.getLogger(__name__)
 
@@ -509,23 +510,11 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
 
         client_capabilities = params.capabilities
         root_uri = params.rootUri
-
-        try:
-            root_path = params.rootPath
-        except AttributeError:
-           root_path = None
-
-        try:
-            client_capabilities = params.capabilities
-        except AttributeError:
-            client_capabilities = None
-        try:
-            workspace_folders = params.workspaceFolders or []
-        except AttributeError:
-            workspace_folders = []
-        if root_uri is None:
-            root_uri = from_fs_path(root_path) if root_path is not None else ''
-
+        root_path = getattr(params, 'rootPath', None)
+        workspace_folders = getattr(params, 'workspaceFolders', [])
+        client_capabilities = getattr(params, 'capabilities', None)
+        if root_path is None:
+            root_path = to_fs_path(root_uri)
         self.workspace = Workspace(root_uri, self)
 
         for folder in workspace_folders:

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -509,7 +509,16 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
 
         client_capabilities = params.capabilities
         root_uri = params.rootUri
-        root_path = params.rootPath
+
+        try:
+            root_path = params.rootPath
+        except AttributeError:
+           root_path = None
+
+        try:
+            client_capabilities = params.capabilities
+        except AttributeError:
+            client_capabilities = None
         try:
             workspace_folders = params.workspaceFolders or []
         except AttributeError:

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -511,7 +511,6 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         root_uri = params.rootUri
         root_path = getattr(params, 'rootPath', None)
         workspace_folders = getattr(params, 'workspaceFolders', [])
-        client_capabilities = getattr(params, 'capabilities', None)
         if root_path is None and root_uri is not None:
             root_path = to_fs_path(root_uri)
         self.workspace = Workspace(root_uri or from_fs_path(root_path), self)

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -42,9 +42,8 @@ from .types import (ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse,
                     ExecuteCommandParams, InitializeParams, InitializeResult,
                     LogMessageParams, MessageType, PublishDiagnosticsParams,
                     ServerCapabilities, ShowMessageParams, WorkspaceEdit)
-from .uris import from_fs_path
+from .uris import from_fs_path, to_fs_path
 from .workspace import Workspace
-from .uris import to_fs_path
 
 logger = logging.getLogger(__name__)
 
@@ -513,9 +512,9 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         root_path = getattr(params, 'rootPath', None)
         workspace_folders = getattr(params, 'workspaceFolders', [])
         client_capabilities = getattr(params, 'capabilities', None)
-        if root_path is None:
+        if root_path is None and root_uri is not None:
             root_path = to_fs_path(root_uri)
-        self.workspace = Workspace(root_uri, self)
+        self.workspace = Workspace(root_uri or from_fs_path(root_path), self)
 
         for folder in workspace_folders:
             self.workspace.add_folder(folder)

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -668,7 +668,7 @@ class InitializeParams:
         self.initializationOptions = initialization_options
         self.capabilities = capabilities
         self.trace = trace
-        self.workspaceFolders = workspace_folders
+        self.workspaceFolders = workspace_folders or []
 
 
 class InitializeResult:

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -26,6 +26,7 @@ from pygls.types import (DidOpenTextDocumentParams, ExecuteCommandParams,
                          InitializeParams, TextDocumentItem)
 from tests import (CMD_ASYNC, CMD_SYNC, CMD_THREAD, FEATURE_ASYNC,
                    FEATURE_SYNC, FEATURE_THREAD)
+import pathlib
 
 CALL_TIMEOUT = 2
 
@@ -33,22 +34,8 @@ CALL_TIMEOUT = 2
 def _initialize_server(server):
     server.lsp.bf_initialize(InitializeParams(
         process_id=1234,
-        root_path=os.path.dirname(__file__)
+        root_uri=pathlib.Path(__file__).parent.as_uri(),
     ))
-
-
-def test_bf_initialize(client_server):
-    client, _ = client_server
-
-    response = client.lsp.send_request(
-        INITIALIZE,
-        InitializeParams(
-            process_id=1234,
-            root_path=os.path.dirname(__file__)
-        )
-    ).result(timeout=CALL_TIMEOUT)
-
-    assert hasattr(response, 'capabilities')
 
 
 def test_bf_initialize_spec(client_server):
@@ -59,7 +46,7 @@ def test_bf_initialize_spec(client_server):
         INITIALIZE,
         {
             "processId": 1234,
-            "rootUri": os.path.dirname(__file__),
+            "rootUri": pathlib.Path(__file__).parent.as_uri(),
             "capabilities": None
         }
     ).result(timeout=CALL_TIMEOUT)

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -55,8 +55,9 @@ def test_bf_initialize_spec(client_server):
     response = client.lsp.send_request(
         INITIALIZE,
         {
-            "process_id": 1234,
-            "root_path": os.path.dirname(__file__)
+            "processId": 1234,
+            "rootUri": os.path.dirname(__file__),
+            "capabilities": None
         }
     ).result(timeout=CALL_TIMEOUT)
 

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -48,6 +48,21 @@ def test_bf_initialize(client_server):
     assert hasattr(response, 'capabilities')
 
 
+def test_bf_initialize_spec(client_server):
+    client, _ = client_server
+    # Use a dictionary to send only the elements marked
+    # as required
+    response = client.lsp.send_request(
+        INITIALIZE,
+        {
+            "process_id": 1234,
+            "root_path": os.path.dirname(__file__)
+        }
+    ).result(timeout=CALL_TIMEOUT)
+
+    assert hasattr(response, 'capabilities')
+
+
 def test_bf_text_document_did_open(client_server):
     client, server = client_server
 


### PR DESCRIPTION
Some LSP clients do not send `workspaceFolders` as a parameter and this line throws an AttributeError on those. Protocol allows for this field to be omitted