### PR TITLE
Fix passing custom protocol to language server + tests

### DIFF
--- a/pygls/server.py
+++ b/pygls/server.py
@@ -213,7 +213,7 @@ class LanguageServer(Server):
 
     def __init__(self, loop=None, protocol_cls=LanguageServerProtocol, max_workers: int = 2):
         assert issubclass(protocol_cls, LanguageServerProtocol)
-        super().__init__(LanguageServerProtocol, loop, max_workers)
+        super().__init__(protocol_cls, loop, max_workers)
 
     def apply_edit(self, edit: WorkspaceEdit, label: str = None) -> ApplyWorkspaceEditResponse:
         """Sends apply edit request to the client."""

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -17,8 +17,11 @@
 import os
 from time import sleep
 
+import pytest
 from pygls.features import (INITIALIZE, TEXT_DOCUMENT_DID_OPEN,
                             WORKSPACE_EXECUTE_COMMAND)
+from pygls.protocol import LanguageServerProtocol
+from pygls.server import LanguageServer
 from pygls.types import (DidOpenTextDocumentParams, ExecuteCommandParams,
                          InitializeParams, TextDocumentItem)
 from tests import (CMD_ASYNC, CMD_SYNC, CMD_THREAD, FEATURE_ASYNC,
@@ -134,3 +137,20 @@ def test_command_thread(client_server):
 
     assert is_called
     assert thread_id != server.thread_id
+
+
+def test_allow_custom_protocol_derived_from_lsp():
+    class CustomProtocol(LanguageServerProtocol):
+        pass
+
+    server = LanguageServer(protocol_cls=CustomProtocol)
+
+    assert isinstance(server.lsp, CustomProtocol)
+
+
+def test_forbid_custom_protocol_not_derived_from_lsp():
+    class CustomProtocol:
+        pass
+
+    with pytest.raises(AssertionError) as e:
+        LanguageServer(protocol_cls=CustomProtocol)


### PR DESCRIPTION
We were passing always the `LanguageServerProtocol` class, instead of parameter from the constructor.