### PR TITLE
Bugfix open workspace assumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Changed
+
+- Fix initialization failure when no workspace is open
+
 ## [0.7.3] - 01/30/2019
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,5 +2,5 @@
 
 - [@augb](https://github.com/augb)
 - [Daniel Elero](https://github.com/danixeee)
-- [yorodm](https://github.com/yorodm)
 - [Max O'Cull](https://github.com/Maxattax97)
+- [yorodm](https://github.com/yorodm)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 - [@augb](https://github.com/augb)
 - [Daniel Elero](https://github.com/danixeee)
 - [yorodm](https://github.com/yorodm)
+- [Max O'Cull](https://github.com/Maxattax97)

--- a/examples/json-extension/server/tests/unit/test_features.py
+++ b/examples/json-extension/server/tests/unit/test_features.py
@@ -17,7 +17,7 @@
 import json
 
 import pytest
-from unittest.mock import Mock
+from mock import Mock
 from pygls.types import (DidCloseTextDocumentParams, DidOpenTextDocumentParams,
                          TextDocumentIdentifier, TextDocumentItem)
 from pygls.workspace import Document, Workspace

--- a/examples/json-extension/server/tests/unit/test_features.py
+++ b/examples/json-extension/server/tests/unit/test_features.py
@@ -17,7 +17,7 @@
 import json
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from pygls.types import (DidCloseTextDocumentParams, DidOpenTextDocumentParams,
                          TextDocumentIdentifier, TextDocumentItem)
 from pygls.workspace import Document, Workspace

--- a/pygls/exceptions.py
+++ b/pygls/exceptions.py
@@ -56,7 +56,7 @@ class JsonRpcException(Exception):
             'message': self.message,
         }
         if self.data is not None:
-            exception_dict['data'] = self.data
+            exception_dict['data'] = str(self.data)
         return exception_dict
 
 

--- a/pygls/exceptions.py
+++ b/pygls/exceptions.py
@@ -29,11 +29,8 @@ class JsonRpcException(Exception):
         self.data = data
 
     def __eq__(self, other):
-        return (
-            isinstance(other, self.__class__) and
-            self.code == other.code and
-            self.message == other.message
-        )
+        return (isinstance(other, self.__class__) and self.code == other.code
+                and self.message == other.message)
 
     def __hash__(self):
         return hash((self.code, self.message))
@@ -56,7 +53,7 @@ class JsonRpcException(Exception):
             'message': self.message,
         }
         if self.data is not None:
-            exception_dict['data'] = self.data
+            exception_dict['data'] = str(self.data)
         return exception_dict
 
 
@@ -68,10 +65,9 @@ class JsonRpcInternalError(JsonRpcException):
     def of(cls, exc_info):
         exc_type, exc_value, exc_tb = exc_info
         return cls(
-            message=''.join(traceback.format_exception_only(
-                exc_type, exc_value)).strip(),
-            data={'traceback': traceback.format_tb(exc_tb)}
-        )
+            message=''.join(
+                traceback.format_exception_only(exc_type, exc_value)).strip(),
+            data={'traceback': traceback.format_tb(exc_tb)})
 
 
 class JsonRpcInvalidParams(JsonRpcException):
@@ -104,12 +100,10 @@ class JsonRpcRequestCancelled(JsonRpcException):
 
 
 class JsonRpcServerError(JsonRpcException):
-
     def __init__(self, message, code, data=None):
         if not _is_server_error_code(code):
             raise ValueError('Error code should be in range -32099 - -32000')
-        super().__init__(
-            message=message, code=code, data=data)
+        super().__init__(message=message, code=code, data=data)
 
     @classmethod
     def supports_code(cls, code):
@@ -144,7 +138,6 @@ class ThreadDecoratorError(Exception):
 
 
 class ValidationError(Exception):
-
     def __init__(self, errors=None):
         self.errors = errors or []
 

--- a/pygls/exceptions.py
+++ b/pygls/exceptions.py
@@ -29,8 +29,11 @@ class JsonRpcException(Exception):
         self.data = data
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__) and self.code == other.code
-                and self.message == other.message)
+        return (
+            isinstance(other, self.__class__) and
+            self.code == other.code and
+            self.message == other.message
+        )
 
     def __hash__(self):
         return hash((self.code, self.message))
@@ -53,7 +56,7 @@ class JsonRpcException(Exception):
             'message': self.message,
         }
         if self.data is not None:
-            exception_dict['data'] = str(self.data)
+            exception_dict['data'] = self.data
         return exception_dict
 
 
@@ -65,9 +68,10 @@ class JsonRpcInternalError(JsonRpcException):
     def of(cls, exc_info):
         exc_type, exc_value, exc_tb = exc_info
         return cls(
-            message=''.join(
-                traceback.format_exception_only(exc_type, exc_value)).strip(),
-            data={'traceback': traceback.format_tb(exc_tb)})
+            message=''.join(traceback.format_exception_only(
+                exc_type, exc_value)).strip(),
+            data={'traceback': traceback.format_tb(exc_tb)}
+        )
 
 
 class JsonRpcInvalidParams(JsonRpcException):
@@ -100,10 +104,12 @@ class JsonRpcRequestCancelled(JsonRpcException):
 
 
 class JsonRpcServerError(JsonRpcException):
+
     def __init__(self, message, code, data=None):
         if not _is_server_error_code(code):
             raise ValueError('Error code should be in range -32099 - -32000')
-        super().__init__(message=message, code=code, data=data)
+        super().__init__(
+            message=message, code=code, data=data)
 
     @classmethod
     def supports_code(cls, code):
@@ -138,6 +144,7 @@ class ThreadDecoratorError(Exception):
 
 
 class ValidationError(Exception):
+
     def __init__(self, errors=None):
         self.errors = errors or []
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -527,7 +527,7 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
 
         # Initialize the workspace
         workspace_folders = getattr(params, 'workspaceFolders', [])
-        self.workspace = Workspace(root_uri, self, workspace_folders)
+        self.workspace = Workspace(root_uri, workspace_folders)
 
         return InitializeResult(server_capabilities)
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -529,8 +529,9 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         self.workspace = Workspace(root_uri, self)
 
         workspace_folders = getattr(params, 'workspaceFolders', [])
-        for folder in workspace_folders:
-            self.workspace.add_folder(folder)
+        if workspace_folders is not None:
+            for folder in workspace_folders:
+                self.workspace.add_folder(folder)
 
         return InitializeResult(server_capabilities)
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -52,6 +52,7 @@ def call_user_feature(base_func, method_name):
     """Wraps generic LSP features and calls user registered feature
     immediately after it.
     """
+
     @functools.wraps(base_func)
     def decorator(self, *args, **kwargs):
         ret_val = base_func(self, *args, **kwargs)
@@ -63,8 +64,8 @@ def call_user_feature(base_func, method_name):
             pass
         except Exception:
             logger.exception(
-                'Failed to handle *user defined* notification {}: {}'
-                .format(method_name, args))
+                'Failed to handle *user defined* notification {}: {}'.format(
+                    method_name, args))
 
         return ret_val
 
@@ -82,8 +83,7 @@ def deserialize_message(data):
         else:
             return JsonRPCNotification(**data)
 
-    return namedtuple('Object',
-                      data.keys())(*data.values())
+    return namedtuple('Object', data.keys())(*data.values())
 
 
 def to_lsp_name(method_name):
@@ -100,7 +100,7 @@ def to_lsp_name(method_name):
         if ch == '_':
             continue
 
-        if m_chars[i-1] == '_':
+        if m_chars[i - 1] == '_':
             m_replaced.append(ch.capitalize())
             continue
 
@@ -203,8 +203,8 @@ class JsonRPCProtocol(asyncio.Protocol):
         """Success callback used for coroutine notification message."""
         if future.exception():
             error = JsonRpcInternalError.of(sys.exc_info()).to_dict()
-            logger.exception('Exception occurred in notification: {}'
-                             .format(error))
+            logger.exception(
+                'Exception occurred in notification: {}'.format(error))
 
             # Revisit. Client does not support response with msg_id = None
             # https://stackoverflow.com/questions/31091376/json-rpc-2-0-allow-notifications-to-have-an-error-response
@@ -215,8 +215,8 @@ class JsonRPCProtocol(asyncio.Protocol):
         if asyncio.iscoroutinefunction(handler):
             future = asyncio.ensure_future(handler(params))
             self._client_request_futures[msg_id] = future
-            future.add_done_callback(partial(self._execute_request_callback,
-                                             msg_id))
+            future.add_done_callback(
+                partial(self._execute_request_callback, msg_id))
         else:
             # Can't be canceled
             if is_thread_function(handler):
@@ -241,16 +241,16 @@ class JsonRPCProtocol(asyncio.Protocol):
             self._client_request_futures.pop(msg_id, None)
         except Exception:
             error = JsonRpcInternalError.of(sys.exc_info()).to_dict()
-            logger.exception('Exception occurred for message {}: {}'
-                             .format(msg_id, error))
+            logger.exception('Exception occurred for message {}: {}'.format(
+                msg_id, error))
             self._send_response(msg_id, error=error)
 
     def _execute_request_err_callback(self, msg_id, exc):
         """Error callback used for coroutine request message."""
         exc_info = (type(exc), exc, None)
         error = JsonRpcInternalError.of(exc_info).to_dict()
-        logger.exception('Exception occurred for message {}: {}'
-                         .format(msg_id, error))
+        logger.exception('Exception occurred for message {}: {}'.format(
+            msg_id, error))
         self._send_response(msg_id, error=error)
 
     def _get_handler(self, feature_name):
@@ -268,8 +268,8 @@ class JsonRPCProtocol(asyncio.Protocol):
         future = self._client_request_futures.pop(msg_id, None)
 
         if not future:
-            logger.warning('Cancel notification for unknown message id {}'
-                           .format(msg_id))
+            logger.warning(
+                'Cancel notification for unknown message id {}'.format(msg_id))
             return
 
         # Will only work if the request hasn't started executing
@@ -286,11 +286,12 @@ class JsonRPCProtocol(asyncio.Protocol):
             handler = self._get_handler(method_name)
             self._execute_notification(handler, params)
         except KeyError:
-            logger.warning('Ignoring notification for unknown method {}'
-                           .format(method_name))
+            logger.warning(
+                'Ignoring notification for unknown method {}'.format(
+                    method_name))
         except Exception:
-            logger.exception('Failed to handle notification {}: {}'
-                             .format(method_name, params))
+            logger.exception('Failed to handle notification {}: {}'.format(
+                method_name, params))
 
     def _handle_request(self, msg_id, method_name, params):
         """Handles a request from the client."""
@@ -304,12 +305,12 @@ class JsonRPCProtocol(asyncio.Protocol):
                 self._execute_request(msg_id, handler, params)
 
         except JsonRpcException as e:
-            logger.exception('Failed to handle request {} {} {}'
-                             .format(msg_id, method_name, params))
+            logger.exception('Failed to handle request {} {} {}'.format(
+                msg_id, method_name, params))
             self._send_response(msg_id, None, e.to_dict())
         except Exception:
-            logger.exception('Failed to handle request {} {} {}'
-                             .format(msg_id, method_name, params))
+            logger.exception('Failed to handle request {} {} {}'.format(
+                msg_id, method_name, params))
             err = JsonRpcInternalError.of(sys.exc_info()).to_dict()
             self._send_response(msg_id, None, err)
 
@@ -318,17 +319,17 @@ class JsonRPCProtocol(asyncio.Protocol):
         future = self._server_request_futures.pop(msg_id, None)
 
         if not future:
-            logger.warning('Received response to unknown message id {}'
-                           .format(msg_id))
+            logger.warning(
+                'Received response to unknown message id {}'.format(msg_id))
             return
 
         if error is not None:
-            logger.debug('Received error response to message {}: {}'
-                         .format(msg_id, error))
+            logger.debug('Received error response to message {}: {}'.format(
+                msg_id, error))
             future.set_exception(JsonRpcException.from_dict(error))
 
-        logger.debug('Received result for message {}: {}'
-                     .format(msg_id, result))
+        logger.debug('Received result for message {}: {}'.format(
+            msg_id, result))
         future.set_result(result)
 
     def _procedure_handler(self, message):
@@ -360,14 +361,10 @@ class JsonRPCProtocol(asyncio.Protocol):
             body = json.dumps(data, default=lambda o: o.__dict__)
             content_length = len(body.encode(self.CHARSET)) if body else 0
 
-            response = (
-                'Content-Length: {}\r\n'
-                'Content-Type: {}; charset={}\r\n\r\n'
-                '{}'.format(content_length,
-                            self.CONTENT_TYPE,
-                            self.CHARSET,
-                            body)
-            )
+            response = ('Content-Length: {}\r\n'
+                        'Content-Type: {}; charset={}\r\n\r\n'
+                        '{}'.format(content_length, self.CONTENT_TYPE,
+                                    self.CHARSET, body))
 
             logger.info('Sending data: {}'.format(body))
 
@@ -383,10 +380,8 @@ class JsonRPCProtocol(asyncio.Protocol):
             result(any): Result returned by handler
             error(any): Error returned by handler
         """
-        response = JsonRPCResponseMessage(msg_id,
-                                          JsonRPCProtocol.VERSION,
-                                          result,
-                                          error)
+        response = JsonRPCResponseMessage(msg_id, JsonRPCProtocol.VERSION,
+                                          result, error)
         self._send_data(response)
 
     def connection_made(self, transport: asyncio.Transport):
@@ -401,8 +396,9 @@ class JsonRPCProtocol(asyncio.Protocol):
             try:
                 body = JsonRPCProtocol.BODY_PATTERN.findall(part)[0]
                 self._procedure_handler(
-                    json.loads(body.decode(self.CHARSET),
-                               object_hook=deserialize_message))
+                    json.loads(
+                        body.decode(self.CHARSET),
+                        object_hook=deserialize_message))
             except IndexError:
                 pass
 
@@ -411,10 +407,7 @@ class JsonRPCProtocol(asyncio.Protocol):
         logger.debug('Sending notification: {} {}'.format(method, params))
 
         request = JsonRPCNotification(
-            jsonrpc=JsonRPCProtocol.VERSION,
-            method=method,
-            params=params
-        )
+            jsonrpc=JsonRPCProtocol.VERSION, method=method, params=params)
 
         self._send_data(request)
 
@@ -429,15 +422,14 @@ class JsonRPCProtocol(asyncio.Protocol):
             Future that will be resolved once a response has been received
         """
         msg_id = str(uuid.uuid4())
-        logger.debug('Sending request with id {}: {} {}'
-                     .format(msg_id, method, params))
+        logger.debug('Sending request with id {}: {} {}'.format(
+            msg_id, method, params))
 
         request = JsonRPCRequestMessage(
             id=msg_id,
             jsonrpc=JsonRPCProtocol.VERSION,
             method=method,
-            params=params
-        )
+            params=params)
 
         future = Future()
 
@@ -457,14 +449,15 @@ class LSPMeta(type):
     Built-in features cannot be overridden but user defined features with
     the same LSP name will be called after them.
     """
+
     def __new__(mcs, cls_name, cls_bases, cls):
         for attr_name, attr_val in cls.items():
             if callable(attr_val) and attr_name.startswith('bf_'):
                 method_name = to_lsp_name(attr_name[3:])
                 cls[attr_name] = call_user_feature(attr_val, method_name)
 
-                logger.debug('Added decorator for lsp method: {}'
-                             .format(attr_name))
+                logger.debug(
+                    'Added decorator for lsp method: {}'.format(attr_name))
 
         return super().__new__(mcs, cls_name, cls_bases, cls)
 
@@ -515,22 +508,22 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
 
         # Initialize server capabilities
         client_capabilities = params.capabilities
-        server_capabilities = ServerCapabilities(self.fm.features.keys(),
-                                                 self.fm.feature_options,
-                                                 self.fm.commands,
-                                                 client_capabilities)
-        logger.debug('Server capabilities: {}'
-                     .format(server_capabilities.__dict__))
+        server_capabilities = ServerCapabilities(
+            self.fm.features.keys(), self.fm.feature_options, self.fm.commands,
+            client_capabilities)
+        logger.debug('Server capabilities: {}'.format(
+            server_capabilities.__dict__))
 
-        root_path = getattr(params, 'rootPath',  None)
+        root_path = getattr(params, 'rootPath', None)
         root_uri = params.rootUri or from_fs_path(root_path)
 
         # Initialize the workspace
         self.workspace = Workspace(root_uri, self)
 
         workspace_folders = getattr(params, 'workspaceFolders', [])
-        for folder in workspace_folders:
-            self.workspace.add_folder(folder)
+        if workspace_folders is not None:
+            for folder in workspace_folders:
+                self.workspace.add_folder(folder)
 
         return InitializeResult(server_capabilities)
 
@@ -557,19 +550,16 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         for change in params.contentChanges:
             self.workspace.update_document(params.textDocument, change)
 
-    def bf_text_document__did_close(self,
-                                    params: DidCloseTextDocumentParams):
+    def bf_text_document__did_close(self, params: DidCloseTextDocumentParams):
         """Removes document from workspace."""
         self.workspace.remove_document(params.textDocument.uri)
 
-    def bf_text_document__did_open(self,
-                                   params: DidOpenTextDocumentParams):
+    def bf_text_document__did_open(self, params: DidOpenTextDocumentParams):
         """Puts document to the workspace."""
         self.workspace.put_document(params.textDocument)
 
     def bf_workspace__did_change_workspace_folders(
-            self,
-            params: DidChangeWorkspaceFoldersParams):
+            self, params: DidChangeWorkspaceFoldersParams):
         """Adds/Removes folders from the workspace."""
         logger.info('Workspace folders changed: {}'.format(params))
 
@@ -582,8 +572,7 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
             if f_remove:
                 self.workspace.remove_folder(f_remove.uri)
 
-    def bf_workspace__execute_command(self,
-                                      params: ExecuteCommandParams,
+    def bf_workspace__execute_command(self, params: ExecuteCommandParams,
                                       msg_id):
         """Executes commands with passed arguments and returns a value."""
         cmd_handler = self.fm.commands[params.command]
@@ -601,10 +590,11 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
             response has been received
         """
         if callback:
+
             def configuration(future: Future):
                 result = future.result()
-                logger.info('Configuration for {} received: {}'
-                            .format(params, result))
+                logger.info('Configuration for {} received: {}'.format(
+                    params, result))
                 return callback(result)
 
             request_future = self.send_request(WORKSPACE_CONFIGURATION, params)

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -526,12 +526,8 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         root_uri = params.rootUri or from_fs_path(root_path)
 
         # Initialize the workspace
-        self.workspace = Workspace(root_uri, self)
-
         workspace_folders = getattr(params, 'workspaceFolders', [])
-        if workspace_folders is not None:
-            for folder in workspace_folders:
-                self.workspace.add_folder(folder)
+        self.workspace = Workspace(root_uri, self, workspace_folders)
 
         return InitializeResult(server_capabilities)
 

--- a/pygls/workspace.py
+++ b/pygls/workspace.py
@@ -128,13 +128,16 @@ class Document(object):
 
 class Workspace(object):
 
-    def __init__(self, root_uri, lsp):
+    def __init__(self, root_uri, workspace_folders=[]):
         self._root_uri = root_uri
-        self._lsp = lsp
         self._root_uri_scheme = uri_scheme(self._root_uri)
         self._root_path = to_fs_path(self._root_uri)
         self._folders = {}
         self._docs = {}
+
+        if workspace_folders is not None:
+            for folder in workspace_folders:
+                self.add_folder(folder)
 
     def _create_document(self,
                          doc_uri: str,

--- a/pygls/workspace.py
+++ b/pygls/workspace.py
@@ -128,7 +128,7 @@ class Document(object):
 
 class Workspace(object):
 
-    def __init__(self, root_uri, workspace_folders=[]):
+    def __init__(self, root_uri, workspace_folders=None):
         self._root_uri = root_uri
         self._root_uri_scheme = uri_scheme(self._root_uri)
         self._root_path = to_fs_path(self._root_uri)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ import os
 from threading import Thread
 
 import pytest
-from mock import Mock
 from pygls import features, uris
 from pygls.feature_manager import FeatureManager
 from pygls.server import LanguageServer
@@ -91,4 +90,4 @@ def feature_manager():
 @pytest.fixture
 def workspace(tmpdir):
     """Return a workspace."""
-    return Workspace(uris.from_fs_path(str(tmpdir)), Mock())
+    return Workspace(uris.from_fs_path(str(tmpdir)))

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -18,7 +18,7 @@
 ############################################################################
 import os
 
-from pygls import uris
+from pygls import uris, Workspace
 from pygls.types import TextDocumentItem, WorkspaceFolder
 
 
@@ -66,3 +66,12 @@ def test_remove_document(workspace):
     assert workspace.get_document(DOC_URI).source == DOC_TEXT
     workspace.remove_document(DOC_URI)
     assert workspace.get_document(DOC_URI)._source is None
+
+def test_workspace_folders():
+    wf1 = WorkspaceFolder('/ws/f1', 'ws1')
+    wf2 = WorkspaceFolder('/ws/f2', 'ws2')
+
+    workspace = Workspace('/ws', [wf1, wf2])
+
+    assert workspace.folders['/ws/f1'] is wf1
+    assert workspace.folders['/ws/f2'] is wf2

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -18,9 +18,9 @@
 ############################################################################
 import os
 
-from pygls import uris, Workspace
+from pygls import uris
+from pygls.workspace import Workspace
 from pygls.types import TextDocumentItem, WorkspaceFolder
-
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC_TEXT = '''test'''
@@ -66,6 +66,7 @@ def test_remove_document(workspace):
     assert workspace.get_document(DOC_URI).source == DOC_TEXT
     workspace.remove_document(DOC_URI)
     assert workspace.get_document(DOC_URI)._source is None
+
 
 def test_workspace_folders():
     wf1 = WorkspaceFolder('/ws/f1', 'ws1')


### PR DESCRIPTION
This fixes #50 by allowing a fresh VS Code session with no workspaces open to not halt the language server.

It also fixes the error message by converting the data property into a string (rather than `[object Object]`).

I apologize for my formatting slip up, I pushed to my fork _then_ realized NeoVim auto-formatted the rest of the code... so a bit of commit bloat.

# How to reproduce
1. Setup VS Code so that the next time it opens, there are no workspaces opened.
2. Enter VS Code in debug mode with the extension loaded.
3. Open a JSON file and start writing.
4. Crashes.

# Critical [line](https://github.com/openlawlibrary/pygls/pull/51/commits/820f85a9e42303173b76bef56c54610abf9b6fee#diff-f04f719a2092ca4cc1f1b05b8f7181a3L532) of code
```
        workspace_folders = getattr(params, 'workspaceFolders', [])
        for folder in workspace_folders:
            self.workspace.add_folder(folder)
```

# VS Code Error
```
[Error - 12:11:01 AM] Server initialization failed.
  Message: TypeError: 'NoneType' object is not iterable
  Code: -32602 
[object Object]
```
This is now fixed so it prints a full traceback instead of `[object Object]`.