### PR TITLE
Not include error field on response message if there is no error

### DIFF
--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -154,7 +154,8 @@ class JsonRPCResponseMessage:
         self.id = id
         self.jsonrpc = jsonrpc
         self.result = result
-        self.error = error
+        if error is not None:
+            self.error = error
 
 
 class JsonRPCProtocol(asyncio.Protocol):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

If a request is successfully finished, `error` field is not needed.

https://microsoft.github.io/language-server-protocol/specification#response-message

The error object creates when a request is failed.

```
/**
	 * The error object in case a request fails.
	 */
	error?: ResponseError<any>;
```

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md

EDIT: Moved description under "Description" heading.