### PR TITLE
Remove error or result field when sending JsonRPCResponseMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Response object should contain result OR error field ([#64])
 - Fix handling parameters whose names are reserved by Python ([#56])
 
-[#56]: https://github.com/openlawlibrary/pygls/pull/56
+[#64]: https://github.com/openlawlibrary/pygls/pull/64
 [#61]: https://github.com/openlawlibrary/pygls/pull/61
+[#56]: https://github.com/openlawlibrary/pygls/pull/56
 
 ## [0.7.4] - 03/21/2019
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -156,6 +156,13 @@ class JsonRPCResponseMessage:
         self.result = result
         self.error = error
 
+    def without_none_fields(self):
+        if self.result:
+            del self.error
+        else:
+            del self.result
+        return self
+
 
 class JsonRPCProtocol(asyncio.Protocol):
     """Json RPC protocol implementation using on top of `asyncio.Protocol`.
@@ -386,7 +393,7 @@ class JsonRPCProtocol(asyncio.Protocol):
                                           JsonRPCProtocol.VERSION,
                                           result,
                                           error)
-        self._send_data(response)
+        self._send_data(response.without_none_fields())
 
     def connection_made(self, transport: asyncio.Transport):
         """Method from base class, called when connection is established"""

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -152,6 +152,24 @@ def test_initialize_should_return_server_capabilities(client_server):
     assert isinstance(server_capabilities, InitializeResult)
 
 
+def test_response_object_fields():
+    # Result field set
+    response = JsonRPCResponseMessage(0, '2.0', 'result', None).without_none_fields()
+
+    assert hasattr(response, 'id')
+    assert hasattr(response, 'jsonrpc')
+    assert hasattr(response, 'result')
+    assert not hasattr(response, 'error')
+
+    # Error field set
+    response = JsonRPCResponseMessage(0, '2.0', None, 'error').without_none_fields()
+
+    assert hasattr(response, 'id')
+    assert hasattr(response, 'jsonrpc')
+    assert hasattr(response, 'error')
+    assert not hasattr(response, 'result')
+
+
 def test_to_lsp_name():
     f_name = 'text_document__did_open'
     name = 'textDocument/didOpen'

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -71,7 +71,12 @@ def test_deserialize_message_without_jsonrpc_field__should_return_object():
 
     assert type(result).__name__ == 'Object'
     assert result.random == "data"
-    assert result._1 == "def"
+
+    # namedtuple does not guarantee field order
+    try:
+        assert result._0 == "def"
+    except AttributeError:
+        assert result._1 == "def"
 
 
 def test_deserialize_message_should_return_response_message():


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #63.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
