### PR TITLE
Fix full updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Changed
+
+- Fix Full SyncKind for servers accepting Incremental SyncKind ([#78])
+
+[#78]: https://github.com/openlawlibrary/pygls/pull/78
+
 ## [0.8.0] - 05/13/2019
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,5 +3,6 @@
 - [@augb](https://github.com/augb)
 - [Daniel Elero](https://github.com/danixeee)
 - [Max O'Cull](https://github.com/Maxattax97)
+- [Samuel Roeca](https://github.com/pappasam)
 - [Tomoya Tanjo](https://github.com/tom-tan)
 - [yorodm](https://github.com/yorodm)

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -1126,7 +1126,7 @@ class TextDocumentClientCapabilities:
 class TextDocumentContentChangeEvent:
     def __init__(self, range: 'Range', range_length: NumType, text: str):
         self.range = range
-        self.range_length = range_length
+        self.rangeLength = range_length
         self.text = text
 
 

--- a/pygls/workspace.py
+++ b/pygls/workspace.py
@@ -110,7 +110,7 @@ class Document(object):
             Even if a server accepts INCREMENTAL SyncKinds, clients may request
             a FULL SyncKind. In LSP 3.x, clients make this request by omitting
             both Range and RangeLength from their request. Consequently, the
-            attributes "range" and "range_length" will be missing from FULL
+            attributes "range" and "rangeLength" will be missing from FULL
             content update client requests in the pygls Python library.
 
         Improvements:
@@ -124,7 +124,7 @@ class Document(object):
         """
         if (
             hasattr(change, 'range') and
-            hasattr(change, 'range_length') and
+            hasattr(change, 'rangeLength') and
             self._is_sync_kind_incremental
         ):
             self._apply_incremental_change(change)
@@ -132,7 +132,7 @@ class Document(object):
             self._apply_none_change(change)
         elif not (
             hasattr(change, 'range') or
-            hasattr(change, 'range_length')
+            hasattr(change, 'rangeLength')
         ):
             self._apply_full_change(change)
         else:

--- a/pygls/workspace.py
+++ b/pygls/workspace.py
@@ -106,9 +106,6 @@ class Document(object):
         Performs either INCREMENTAL, FULL, or NONE synchronization based on
         both the Client request and server capabilities.
 
-        Raises ValueError if the client provides an ambiguous or unsupported
-        request.
-
         INCREMENTAL versus FULL synchronization:
             Even if a server accepts INCREMENTAL SyncKinds, clients may request
             a FULL SyncKind. In LSP 3.x, clients make this request by omitting


### PR DESCRIPTION
## Description

FULL syncs were broken for me unless I set the server to only accept FULL syncs. This PR fixes the bug.

## Discussion

Even if a server accepts INCREMENTAL SyncKinds, clients may request a FULL SyncKind. In LSP 3.x, clients make this request by omitting both Range and RangeLength from their request. Consequently, the attributes "range" and "range_length" will be missing from FULL content update client requests in the pygls Python library.

The client library I use is [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim), which only supports full updates at present. It explicitly removes the attributes Range and RangeLength from its request when they are None, as the LSP specification requests. This clearly flows to the lower-level `_apply_incremental_change(` function.

I haven't been able to fully wrap my head around the lower-level parts of this library (types.py -> protocol.py), so maybe you can find a more elegant solution than this one. That said, this is currently a breaking bug, and this PR fixes the problem, enabling me to not explicitly override the server's sync settings to only support FULL.

NOTE: I haven't updated tests (not sure which to update) or the ChangeLog (will wait until I get confirmation that you like this PR before doing that).

Docs:

* DidChange: https://microsoft.github.io/language-server-protocol/specification#textDocument_didChange
* Optional Properties: https://www.typescriptlang.org/docs/handbook/interfaces.html#optional-properties

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
