### PR TITLE
Fix message parsing for documents containing Content-Length keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 - Response object should contain result OR error field ([#64])
 - Fix handling parameters whose names are reserved by Python ([#56])
+- Fix parsing of partial messages and those with Content-Length keyword ([#80])
 
 [#67]: https://github.com/openlawlibrary/pygls/pull/67
 [#65]: https://github.com/openlawlibrary/pygls/pull/65

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Changed
+
+- Fix parsing of partial messages and those with Content-Length keyword ([#80])
+
 ## [0.8.0] - 05/13/2019
 
 ### Added
@@ -20,7 +24,6 @@ and this project adheres to [Semantic Versioning][semver].
 
 - Response object should contain result OR error field ([#64])
 - Fix handling parameters whose names are reserved by Python ([#56])
-- Fix parsing of partial messages and those with Content-Length keyword ([#80])
 
 [#67]: https://github.com/openlawlibrary/pygls/pull/67
 [#65]: https://github.com/openlawlibrary/pygls/pull/65

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,7 +2,7 @@
 
 - [@augb](https://github.com/augb)
 - [Daniel Elero](https://github.com/danixeee)
+- [Denis Loginov](https://github.com/dinvlad)
 - [Max O'Cull](https://github.com/Maxattax97)
 - [Tomoya Tanjo](https://github.com/tom-tan)
 - [yorodm](https://github.com/yorodm)
-- [Denis Loginov](https://github.com/dinvlad)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - [Max O'Cull](https://github.com/Maxattax97)
 - [Tomoya Tanjo](https://github.com/tom-tan)
 - [yorodm](https://github.com/yorodm)
+- [Denis Loginov](https://github.com/dinvlad)

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -175,6 +175,15 @@ class JsonRPCProtocol(asyncio.Protocol):
 
     CHARSET = 'utf-8'
     CONTENT_TYPE = 'application/vscode-jsonrpc'
+
+    MESSAGE_PATTERN = re.compile(
+        rb'^(?:[^\r\n]+\r\n)*' +
+        rb'Content-Length: (?P<length>\d+)\r\n' +
+        rb'(?:[^\r\n]+\r\n)*\r\n' +
+        rb'(?P<body>{.*)',
+        re.DOTALL,
+    )
+
     VERSION = '2.0'
 
     def __init__(self, server):
@@ -396,14 +405,6 @@ class JsonRPCProtocol(asyncio.Protocol):
     def connection_made(self, transport: asyncio.Transport):
         """Method from base class, called when connection is established"""
         self.transport = transport
-
-    MESSAGE_PATTERN = re.compile(
-        rb'^(?:[^\r\n]+\r\n)*' +
-        rb'Content-Length: (?P<length>\d+)\r\n' +
-        rb'(?:[^\r\n]+\r\n)*\r\n' +
-        rb'(?P<body>{.*)',
-        re.DOTALL,
-    )
 
     def data_received(self, data: bytes):
         """Method from base class, called when server receives the data"""

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -170,7 +170,6 @@ class JsonRPCProtocol(asyncio.Protocol):
 
     This class provides bidirectional communication which is needed for LSP.
     """
-    BODY_PATTERN = re.compile(rb'^Content-Length: (\d+)\r\n\r\n(.*)')
 
     CANCEL_REQUEST = '$/cancelRequest'
 
@@ -188,6 +187,7 @@ class JsonRPCProtocol(asyncio.Protocol):
 
         self.fm = FeatureManager(server)
         self.transport = None
+        self._message_buf = []
 
     def __call__(self):
         return self
@@ -397,25 +397,40 @@ class JsonRPCProtocol(asyncio.Protocol):
         """Method from base class, called when connection is established"""
         self.transport = transport
 
+    MESSAGE_PATTERN = re.compile(
+        rb'^(?:[^\r\n]+\r\n)*Content-Length: (?P<length>\d+)\r\n(?:[^\r\n]+\r\n)*\r\n(?P<body>{.*)',
+        re.DOTALL,
+    )
+
     def data_received(self, data: bytes):
         """Method from base class, called when server receives the data"""
         logger.debug('Received {}'.format(data))
 
         while len(data):
-            try:
-                m = JsonRPCProtocol.BODY_PATTERN.search(data)
-                if m:
-                    length = int(m.group(1))
-                    body = m.group(2)[0:length]
-                    data = body[length:]
-                else:
-                    body = data
-                    data = ''
-                self._procedure_handler(
-                    json.loads(body.decode(self.CHARSET),
-                               object_hook=deserialize_message))
-            except IndexError:
-                pass
+            # Append the incoming chunk to the message buffer
+            self._message_buf.append(data)
+
+            # Look for the body of the message
+            message = b''.join(self._message_buf)
+            found = JsonRPCProtocol.MESSAGE_PATTERN.fullmatch(message)
+
+            body = found.group('body') if found else b''
+            length = int(found.group('length')) if found else 1
+
+            if len(body) < length:
+                # Message is incomplete; bail until more data arrives
+                return
+
+            # Message is complete;
+            # extract the body and any remaining data,
+            # and reset the buffer for the next message
+            body, data = body[:length], body[length:]
+            self._message_buf = []
+
+            # Parse the body
+            self._procedure_handler(
+                json.loads(body.decode(self.CHARSET),
+                            object_hook=deserialize_message))
 
     def notify(self, method: str, params=None):
         """Sends a JSON RPC notification to the client."""

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -398,7 +398,10 @@ class JsonRPCProtocol(asyncio.Protocol):
         self.transport = transport
 
     MESSAGE_PATTERN = re.compile(
-        rb'^(?:[^\r\n]+\r\n)*Content-Length: (?P<length>\d+)\r\n(?:[^\r\n]+\r\n)*\r\n(?P<body>{.*)',
+        rb'^(?:[^\r\n]+\r\n)*' +
+        rb'Content-Length: (?P<length>\d+)\r\n' +
+        rb'(?:[^\r\n]+\r\n)*\r\n' +
+        rb'(?P<body>{.*)',
         re.DOTALL,
     )
 
@@ -430,7 +433,7 @@ class JsonRPCProtocol(asyncio.Protocol):
             # Parse the body
             self._procedure_handler(
                 json.loads(body.decode(self.CHARSET),
-                            object_hook=deserialize_message))
+                           object_hook=deserialize_message))
 
     def notify(self, method: str, params=None):
         """Sends a JSON RPC notification to the client."""

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -114,6 +114,75 @@ def test_deserialize_message_should_return_request_message():
     assert result.params == "1"
 
 
+def test_data_received_without_content_type_should_handle_message(client_server):
+    _, server = client_server
+    body = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "test",
+        "params": 1,
+    })
+    message = '\r\n'.join((
+        'Content-Length: ' + str(len(body)),
+        '',
+        body,
+    ))
+    data = dummy_message()
+    server.lsp.data_received(data)
+
+
+def test_data_received_content_type_first_should_handle_message(client_server):
+    _, server = client_server
+    body = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "test",
+        "params": 1,
+    })
+    message = '\r\n'.join((
+        'Content-Type: application/vscode-jsonrpc; charset=utf-8',
+        'Content-Length: ' + str(len(body)),
+        '',
+        body,
+    ))
+    data = dummy_message()
+    server.lsp.data_received(data)
+
+
+def dummy_message(param = 1):
+    body = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "test",
+        "params": param,
+    })
+    message = '\r\n'.join((
+        'Content-Length: ' + str(len(body)),
+        'Content-Type: application/vscode-jsonrpc; charset=utf-8',
+        '',
+        body,
+    ))
+    return bytes(message, 'utf-8')
+
+
+def test_data_received_single_message_should_handle_message(client_server):
+    _, server = client_server
+    data = dummy_message()
+    server.lsp.data_received(data)
+
+
+def test_data_received_partial_message_should_handle_message(client_server):
+    _, server = client_server
+    data = dummy_message()
+    partial = len(data) - 5
+    server.lsp.data_received(data[:partial])
+    server.lsp.data_received(data[partial:])
+
+
+def test_data_received_multi_message_should_handle_messages(client_server):
+    _, server = client_server
+    messages = (dummy_message(i) for i in range(3))
+    data = b''.join(messages)
+    server.lsp.data_received(data)
+
+
 def test_initialize_without_capabilities_should_raise_error(client_server):
     _, server = client_server
     params = dictToObj({

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -126,7 +126,7 @@ def test_data_received_without_content_type_should_handle_message(client_server)
         '',
         body,
     ))
-    data = dummy_message()
+    data = bytes(message, 'utf-8')
     server.lsp.data_received(data)
 
 
@@ -143,11 +143,11 @@ def test_data_received_content_type_first_should_handle_message(client_server):
         '',
         body,
     ))
-    data = dummy_message()
+    data = bytes(message, 'utf-8')
     server.lsp.data_received(data)
 
 
-def dummy_message(param = 1):
+def dummy_message(param=1):
     body = json.dumps({
         "jsonrpc": "2.0",
         "method": "test",


### PR DESCRIPTION
## Description

This PR fixes the logic for parsing a batch of messages in `data_received()`, where each message body may contain a literal `Content-Length` keyword.

Previously, if a document contained this keyword, then the server would crash, because it attempted to split messages on this keyword.

Now, instead of splitting the messages on the keyword, it parses content length from the first keyword, and then extracts the message based on the length. After that, the parsing loop is repeated, until no more messages can be read.

Update: I added handling of partial messages, since some messages may arrive in chunks.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
