### PR TITLE
server: more specific types for decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed `@command`, `@feature` and `@thread` decorators to retain type of wrapped functions ([#89])
+
+[#89]: https://github.com/openlawlibrary/pygls/pull/89
+
 ### Added
 
 - Add comparisons and repr support to Range and Location types ([#90])

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -21,7 +21,7 @@ import sys
 from concurrent.futures import Future, ThreadPoolExecutor
 from multiprocessing.pool import ThreadPool
 from threading import Event
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, TypeVar
 
 from pygls.types import (ApplyWorkspaceEditResponse, ConfigCallbackType, Diagnostic, MessageType,
                          RegistrationParams, TextDocumentSyncKind, UnregistrationParams,
@@ -33,6 +33,8 @@ from .types import ConfigurationParams
 from .workspace import Workspace
 
 logger = logging.getLogger(__name__)
+
+F = TypeVar('F', bound=Callable)
 
 
 async def aio_readline(loop, executor, stop_event, rfile, proxy):
@@ -234,7 +236,7 @@ class LanguageServer(Server):
         """Sends apply edit request to the client."""
         return self.lsp.apply_edit(edit, label)
 
-    def command(self, command_name: str) -> Callable:
+    def command(self, command_name: str) -> Callable[[F], F]:
         """Decorator used to register custom commands.
 
         Example:
@@ -244,7 +246,7 @@ class LanguageServer(Server):
         """
         return self.lsp.fm.command(command_name)
 
-    def feature(self, feature_name: str, **options: Dict) -> Callable:
+    def feature(self, feature_name: str, **options: Dict) -> Callable[[F], F]:
         """Decorator used to register LSP features.
 
         Example:
@@ -287,7 +289,7 @@ class LanguageServer(Server):
         """Sends message to the client's output channel."""
         self.lsp.show_message_log(message, msg_type)
 
-    def thread(self) -> Callable:
+    def thread(self) -> Callable[[F], F]:
         """Decorator that mark function to execute it in a thread."""
         return self.lsp.thread()
 


### PR DESCRIPTION
## Description

Use a TypeVar so that type checkers understand that the signature is
same as the decorated functions, so that these functions can be
typechecked.

fixes #88

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
