### PR TITLE
PEP561: Declare that this package has inline types

### DIFF
--- a/pygls/py.typed
+++ b/pygls/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561. The pygls package uses inline types.
+

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setup(
             './CHANGELOG.md',
             './LICENSE.txt',
             './README.md',
-            'ThirdPartyNotices.txt'
+            'ThirdPartyNotices.txt',
+            './pygls/py.typed'
         ])
     ],
     zip_safe=False,


### PR DESCRIPTION
## Description

See https://www.python.org/dev/peps/pep-0561/ . With such package metadata users of pygls running type checkers will use the type definitions provided by pygls and won't have to manage stubs themselves.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
