### PR TITLE
types: use enum class for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning][semver].
 ### Added
 
 - Add comparisons and repr support to Range and Location types ([#90])
+- Use python enums in types module ([#92])
 
 [#90]: https://github.com/openlawlibrary/pygls/pull/90
+[#92]: https://github.com/openlawlibrary/pygls/pull/92
 
 ## [0.8.1] - 09/05/2019
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -15,6 +15,7 @@
 # limitations under the License.                                           #
 ############################################################################
 import asyncio
+import enum
 import functools
 import json
 import logging
@@ -67,6 +68,13 @@ def call_user_feature(base_func, method_name):
         return ret_val
 
     return decorator
+
+
+def default_serializer(o):
+    """JSON serializer for complex objects."""
+    if isinstance(o, enum.Enum):
+        return o.value
+    return o.__dict__
 
 
 def deserialize_message(data):
@@ -370,7 +378,7 @@ class JsonRPCProtocol(asyncio.Protocol):
             return
 
         try:
-            body = json.dumps(data, default=lambda o: o.__dict__)
+            body = json.dumps(data, default=default_serializer)
             content_length = len(body.encode(self.CHARSET)) if body else 0
 
             response = (


### PR DESCRIPTION
## Description 

Using enums allows more precise type checking. The current code in types.py was already using *Kind classes as if they were enums, which mypy reported as type errors:
    
    pygls/types.py:377: error: Incompatible default for argument "severity" (default has type "int", argument has type "DiagnosticSeverity")
    pygls/types.py:663: error: Incompatible default for argument "trace" (default has type "str", argument has type "Optional[Trace]")

WatchKind is handled a bit differently, because valid values can be combined with |, like the default value 7.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
