### PR TITLE
docstrings: use triggerCharacters, not trigger_characters

### DIFF
--- a/pygls/feature_manager.py
+++ b/pygls/feature_manager.py
@@ -137,7 +137,7 @@ class FeatureManager:
         """Decorator used to register LSP features.
 
         Example:
-            @ls.feature('textDocument/completion', triggerCharacters=['.'])
+            @ls.feature('textDocument/completion', trigger_characters=['.'])
         """
         def decorator(f):
             # Validate

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -248,7 +248,7 @@ class LanguageServer(Server):
         """Decorator used to register LSP features.
 
         Example:
-            @ls.feature('textDocument/completion', triggerCharacters=['.'])
+            @ls.feature('textDocument/completion', trigger_characters=['.'])
             def completions(ls, params: CompletionRequest):
                 return CompletionList(False, [CompletionItem("Completion 1")])
         """


### PR DESCRIPTION
## Description

There's a small typo in docstrings, language server protocol uses `triggerCharacters`, but pygls uses `trigger_characters` here.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
