### PR TITLE
Add zc.buildout Language Server to Implementations

### DIFF
--- a/Implementations.md
+++ b/Implementations.md
@@ -5,5 +5,6 @@
 | _Cmake Language Server_  | [Regen100](https://github.com/regen100)                               | [cmake-language-server](https://github.com/regen100/cmake-language-server) | CMake LSP Implementation
 | _Codify Language Server_ | [Open Law Library](http://www.openlawlib.org/)                        | &nbsp;                                                                     | Used in our VS Code extension, _[Codify](https://marketplace.visualstudio.com/items?itemName=openlawlibrary.open-law-codify)_ |
 | _Jedi Language Server_   | [Samuel Roeca](https://softwarejourneyman.com/pages/about.html#about) | [jedi-language-server](https://github.com/pappasam/jedi-language-server)   | Python language server wrapping [Jedi](https://github.com/davidhalter/jedi)                                                   |
+| _zc.buildout Language Server_   | [Jérome Perrin](https://github.com/perrinjerome) | [zc.buildout.languageserver](https://github.com/perrinjerome/vscode-zc-buildout)   | Language server for [zc.buildout](http://docs.buildout.org/en/latest/) profiles.  |
 
 ## _(alphabetic by name, maintainer)_


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Adding reference to a language server I wrote for [zc.buildout](http://docs.buildout.org/en/latest/) profiles.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
