### PR TITLE
Don't install the tests to site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ KEYWORDS = 'python pythonic generic language server protocol'
 LICENSE = 'Apache 2.0'
 URL = 'https://github.com/openlawlibrary/pygls/tree/master/'
 
-packages = find_packages()
+packages = find_packages(exclude=['tests'])
 
 print('packages:', packages)
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Before, `pip install .` or `python setup.py install` would install `/usr/lib/python3.x/site-packages/tests`. This restricts setuptools' package discovery to exclude it.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
