### PR TITLE
Add InsertTextFormat enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/settings.json
 .idea
+.dir-locals.el
 
 *.vsix
 

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -230,7 +230,7 @@ class CompletionItem:
                  sort_text: str = None,
                  filter_text: str = None,
                  insert_text: str = None,
-                 insert_text_format: str = None,
+                 insert_text_format: int = 1,
                  text_edit: 'TextEdit' = None,
                  additional_text_edits: List['TextEdit'] = None,
                  commit_characters: List[str] = None,
@@ -291,6 +291,11 @@ class CompletionItemKind(enum.IntEnum):
 class CompletionItemKindAbstract:
     def __init__(self, value_set: List['CompletionItemKind']):
         self.valueSet = value_set
+
+
+class InsertTextFormat(enum.IntEnum):
+    PlainText = 1
+    Snippet = 2
 
 
 class CompletionList:

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -293,11 +293,6 @@ class CompletionItemKindAbstract:
         self.valueSet = value_set
 
 
-class InsertTextFormat(enum.IntEnum):
-    PlainText = 1
-    Snippet = 2
-
-
 class CompletionList:
     def __init__(self,
                  is_incomplete: bool,
@@ -704,6 +699,11 @@ class InitializeParams:
 class InitializeResult:
     def __init__(self, capabilities: 'ServerCapabilities'):
         self.capabilities = capabilities
+
+
+class InsertTextFormat(enum.IntEnum):
+    PlainText = 1
+    Snippet = 2
 
 
 class Location:

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -230,7 +230,7 @@ class CompletionItem:
                  sort_text: str = None,
                  filter_text: str = None,
                  insert_text: str = None,
-                 insert_text_format: int = 1,
+                 insert_text_format: 'InsertTextFormat' = None,
                  text_edit: 'TextEdit' = None,
                  additional_text_edits: List['TextEdit'] = None,
                  commit_characters: List[str] = None,

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -706,11 +706,6 @@ class InitializeResult:
         self.capabilities = capabilities
 
 
-class InsertTextFormat(enum.IntEnum):
-    PlainText = 1
-    Snippet = 2
-
-
 class Location:
     def __init__(self, uri: str, range: 'Range'):
         self.uri = uri


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Add `InsertTextFormatEnum` for [CompletionItem](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion).
Also change type annotation and default value of `insert_text_format` to `int = 1`.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
