### PR TITLE
py.typed now copied into the built package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed issue where `py.typed` was not copied into setuptools-built package
+
 ## [0.9.0] - 04/20/2020
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     keywords=KEYWORDS,
     license=LICENSE,
     packages=packages,
+    package_data={'': ['py.typed']},
     include_package_data=True,
     data_files=[
         ('lib/site-packages/pygls', [


### PR DESCRIPTION
## Description

`py.typed` was not actually copied into the built package. This PR fixes that.

See here:
https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages

We need to put the copied non-Python `py.typed` in the `package_data`
argument, NOT the `data_files` argument

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
