### PR TITLE
Fix utf-16 to utf-32 character offsets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Added
+
+- Functions to convert positions from and to utf-16 code units ([#117])
+
 ### Changed
 
 - Exit server normally when `ctrl+c` is pressed in command shell.
 - Optimize json-rpc message serialization ([#120])
 
 [#120]: https://github.com/openlawlibrary/pygls/pull/120
+[#117]: https://github.com/openlawlibrary/pygls/pull/117
 
 ## [0.9.0] - 04/20/2020
 

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -839,6 +839,12 @@ class Position:
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash((self.line, self.character))
+
+    def __iter__(self):
+        return iter((self.line, self.character))
+
     def __repr__(self):
         return '{}:{}'.format(self.line, self.character)
 
@@ -864,6 +870,12 @@ class Range:
             isinstance(other, Range)
             and self.start == other.start
             and self.end == other.end)
+
+    def __hash__(self):
+        return hash((self.start, self.end))
+
+    def __iter__(self):
+        return iter((self.start, self.end))
 
     def __repr__(self):
         return '{}-{}'.format(self.start, self.end)

--- a/pygls/workspace.py
+++ b/pygls/workspace.py
@@ -54,11 +54,11 @@ def utf16_num_units(chars: str):
 def position_from_utf16(lines: List[str], position: Position) -> Position:
     """Convert the position.character from utf-16 code units to utf-32.
 
-    A python application can't use the character memeber of `Position`
+    A python application can't use the character member of `Position`
     directly as per specification it is represented as a zero-based line and
-    character offset based based on a UTF-16 string representation.
+    character offset based on a UTF-16 string representation.
 
-    All characters whose codepoint exeeds the Basic Multilingual Plane are
+    All characters whose code point exceeds the Basic Multilingual Plane are
     represented by 2 UTF-16 code units.
 
     The offset of the closing quotation mark in x="😋" is
@@ -69,7 +69,7 @@ def position_from_utf16(lines: List[str], position: Position) -> Position:
 
     Arguments:
         lines (list):
-            The content of the document which the position referes to.
+            The content of the document which the position refers to.
         position (Position):
             The line and character offset in utf-16 code units.
 
@@ -88,11 +88,11 @@ def position_from_utf16(lines: List[str], position: Position) -> Position:
 def position_to_utf16(lines: List[str], position: Position) -> Position:
     """Convert the position.character from utf-32 to utf-16 code units.
 
-    A python application can't use the character memeber of `Position`
+    A python application can't use the character member of `Position`
     directly as per specification it is represented as a zero-based line and
-    character offset based based on a UTF-16 string representation.
+    character offset based on a UTF-16 string representation.
 
-    All characters whose codepoint exeeds the Basic Multilingual Plane are
+    All characters whose code point exceeds the Basic Multilingual Plane are
     represented by 2 UTF-16 code units.
 
     The offset of the closing quotation mark in x="😋" is
@@ -103,7 +103,7 @@ def position_to_utf16(lines: List[str], position: Position) -> Position:
 
     Arguments:
         lines (list):
-            The content of the document which the position referes to.
+            The content of the document which the position refers to.
         position (Position):
             The line and character offset in utf-32 code units.
 
@@ -124,7 +124,7 @@ def range_from_utf16(lines: List[str], range: Range) -> Range:
 
     Arguments:
         lines (list):
-            The content of the document which the range referes to.
+            The content of the document which the range refers to.
         range (Range):
             The line and character offset in utf-32 code units.
 
@@ -142,7 +142,7 @@ def range_to_utf16(lines: List[str], range: Range) -> Range:
 
     Arguments:
         lines (list):
-            The content of the document which the range referes to.
+            The content of the document which the range refers to.
         range (Range):
             The line and character offset in utf-16 code units.
 
@@ -182,7 +182,7 @@ class Document(object):
 
         (start_line, start_col), (end_line, end_col) = range_from_utf16(lines, change_range)
 
-        # Check for an edit occuring at the very end of the file
+        # Check for an edit occurring at the very end of the file
         if start_line == len(lines):
             self._source = self.source + text
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ CALL_TIMEOUT = 2
 DOC = """document
 for
 testing
+with "😋" unicode.
 """
 DOC_URI = uris.from_fs_path(__file__)
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -18,7 +18,10 @@
 ############################################################################
 from pygls.types import (Position, Range, TextDocumentContentChangeEvent,
                          TextDocumentSyncKind)
-from pygls.workspace import Document
+from pygls.workspace import (
+    Document, position_from_utf16, position_to_utf16, range_from_utf16,
+    range_to_utf16, rowcol_to_position, position_to_rowcol
+)
 
 from .conftest import DOC, DOC_URI
 
@@ -118,6 +121,54 @@ def test_document_source_unicode():
     document_mem = Document(DOC_URI, u'my source')
     document_disk = Document(DOC_URI)
     assert isinstance(document_mem.source, type(document_disk.source))
+
+
+def test_rowcol_to_position():
+    assert rowcol_to_position(['x="😋"'], 0, 3) == Position(0, 3)
+    assert rowcol_to_position(['x="😋"'], 0, 4) == Position(0, 5)
+
+
+def test_position_to_rowcol():
+    assert position_to_rowcol(['x="😋"'], Position(0, 3)) == (0, 3)
+    assert position_to_rowcol(['x="😋"'], Position(0, 5)) == (0, 4)
+
+
+def test_position_from_utf16():
+    assert position_from_utf16(['x="😋"'], Position(0, 3)) == Position(0, 3)
+    assert position_from_utf16(['x="😋"'], Position(0, 5)) == Position(0, 4)
+
+    position = Position(0, 5)
+    position_from_utf16(['x="😋"'], position)
+    assert position == Position(0, 4)
+
+
+def test_position_to_utf16():
+    assert position_to_utf16(['x="😋"'], Position(0, 3)) == Position(0, 3)
+    assert position_to_utf16(['x="😋"'], Position(0, 4)) == Position(0, 5)
+
+    position = Position(0, 4)
+    position_to_utf16(['x="😋"'], position)
+    assert position == Position(0, 5)
+
+
+def test_range_from_utf16():
+    assert range_from_utf16(
+        ['x="😋"'], Range(Position(0, 3), Position(0, 5))
+    ) == Range(Position(0, 3), Position(0, 4))
+
+    range = Range(Position(0, 3), Position(0, 5))
+    range_from_utf16(['x="😋"'], range)
+    assert range == Range(Position(0, 3), Position(0, 4))
+
+
+def test_range_to_utf16():
+    assert range_to_utf16(
+        ['x="😋"'], Range(Position(0, 3), Position(0, 4))
+    ) == Range(Position(0, 3), Position(0, 5))
+
+    range = Range(Position(0, 3), Position(0, 4))
+    range_to_utf16(['x="😋"'], range)
+    assert range == Range(Position(0, 3), Position(0, 5))
 
 
 def test_offset_at_position(doc):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -125,6 +125,9 @@ def test_offset_at_position(doc):
     assert doc.offset_at_position(Position(1, 5)) == 14
     assert doc.offset_at_position(Position(2, 0)) == 13
     assert doc.offset_at_position(Position(2, 4)) == 17
+    assert doc.offset_at_position(Position(3, 6)) == 27
+    assert doc.offset_at_position(Position(3, 7)) == 27
+    assert doc.offset_at_position(Position(3, 8)) == 28
     assert doc.offset_at_position(Position(4, 0)) == 39
     assert doc.offset_at_position(Position(5, 0)) == 39
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -74,7 +74,7 @@ def test_document_line_edit():
 
 
 def test_document_lines(doc):
-    assert len(doc.lines) == 3
+    assert len(doc.lines) == 4
     assert doc.lines[0] == 'document\n'
 
 
@@ -125,7 +125,8 @@ def test_offset_at_position(doc):
     assert doc.offset_at_position(Position(1, 5)) == 14
     assert doc.offset_at_position(Position(2, 0)) == 13
     assert doc.offset_at_position(Position(2, 4)) == 17
-    assert doc.offset_at_position(Position(4, 0)) == 21
+    assert doc.offset_at_position(Position(4, 0)) == 39
+    assert doc.offset_at_position(Position(5, 0)) == 39
 
 
 def test_word_at_position(doc):
@@ -136,4 +137,5 @@ def test_word_at_position(doc):
     assert doc.word_at_position(Position(0, 1000)) == 'document'
     assert doc.word_at_position(Position(1, 5)) == 'for'
     assert doc.word_at_position(Position(2, 0)) == 'testing'
+    assert doc.word_at_position(Position(3, 10)) == 'unicode'
     assert doc.word_at_position(Position(4, 0)) == ''

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -19,8 +19,7 @@
 from pygls.types import (Position, Range, TextDocumentContentChangeEvent,
                          TextDocumentSyncKind)
 from pygls.workspace import (
-    Document, position_from_utf16, position_to_utf16, range_from_utf16,
-    range_to_utf16, rowcol_to_position, position_to_rowcol
+    Document, position_from_utf16, position_to_utf16, range_from_utf16, range_to_utf16
 )
 
 from .conftest import DOC, DOC_URI
@@ -123,23 +122,13 @@ def test_document_source_unicode():
     assert isinstance(document_mem.source, type(document_disk.source))
 
 
-def test_rowcol_to_position():
-    assert rowcol_to_position(['x="😋"'], 0, 3) == Position(0, 3)
-    assert rowcol_to_position(['x="😋"'], 0, 4) == Position(0, 5)
-
-
-def test_position_to_rowcol():
-    assert position_to_rowcol(['x="😋"'], Position(0, 3)) == (0, 3)
-    assert position_to_rowcol(['x="😋"'], Position(0, 5)) == (0, 4)
-
-
 def test_position_from_utf16():
     assert position_from_utf16(['x="😋"'], Position(0, 3)) == Position(0, 3)
     assert position_from_utf16(['x="😋"'], Position(0, 5)) == Position(0, 4)
 
     position = Position(0, 5)
     position_from_utf16(['x="😋"'], position)
-    assert position == Position(0, 4)
+    assert position == Position(0, 5)
 
 
 def test_position_to_utf16():
@@ -148,7 +137,7 @@ def test_position_to_utf16():
 
     position = Position(0, 4)
     position_to_utf16(['x="😋"'], position)
-    assert position == Position(0, 5)
+    assert position == Position(0, 4)
 
 
 def test_range_from_utf16():
@@ -158,7 +147,7 @@ def test_range_from_utf16():
 
     range = Range(Position(0, 3), Position(0, 5))
     range_from_utf16(['x="😋"'], range)
-    assert range == Range(Position(0, 3), Position(0, 4))
+    assert range == Range(Position(0, 3), Position(0, 5))
 
 
 def test_range_to_utf16():
@@ -168,7 +157,7 @@ def test_range_to_utf16():
 
     range = Range(Position(0, 3), Position(0, 4))
     range_to_utf16(['x="😋"'], range)
-    assert range == Range(Position(0, 3), Position(0, 5))
+    assert range == Range(Position(0, 3), Position(0, 4))
 
 
 def test_offset_at_position(doc):


### PR DESCRIPTION
Closes #116.

Python uses utf-32 for strings, but the language-server-protocol uses utf-16 to encode strings. Hence higher level unicode code points are represented by two utf-16 code units. Thus the `position.character` needs to be adjusted in case of the presence of such unicode characters.

see: https://github.com/openlawlibrary/pygls/issues/116, https://github.com/microsoft/language-server-protocol/issues/376

This PR therefore introduces two methods to the `Documents` class to handle conversion between utf-16 and utf-32 column offsets for general use.

The new methods are used in the `offset_at_position()`, `word_at_position()` and `_apply_incremental_change()` methods.

Notes:

1. The conversion needs information about the line's content. Hence it feels natural to add the functionality to the Document.

2. This change is unfortunately not transparent. Means a real server needs to proxy all positions through

   a) `Document.rowcol_to_position()` in order to create a `Position` with correct utf-16 code units to be sent to the client.

   b) `Document.position_to_rowcol()` to receive a corrected (row, col) tuple.

3. The methods convert between tuple <-> Position to make the difference clear and because row and column are needed explicitly in the current use cases anyway. A new type could be invented but it would need to make the difference obvious.

5. The `''.join(..)` statement in `offset_at_position()` is replaced as creating a maybe huge string just to count characters while the length of each line is a stored attribute seems too expensive.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
