### PR TITLE
Exit server normally via KeyboardInterrupt exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Changed
+
+- Exit server normally when `ctrl+c` is pressed in command shell.
+
+
 ## [0.9.0] - 04/20/2020
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 - [@augb](https://github.com/augb)
 - [Daniel Elero](https://github.com/danixeee)
+- [DeathAxe](https://github.com/deathaxe)
 - [Denis Loginov](https://github.com/dinvlad)
 - [Jérome Perrin](https://github.com/perrinjerome)
 - [Max O'Cull](https://github.com/Maxattax97)

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -177,7 +177,7 @@ class Server:
                              self._stop_event,
                              stdin or sys.stdin.buffer,
                              self.lsp.data_received))
-        except SystemExit:
+        except (KeyboardInterrupt, SystemExit):
             pass
         finally:
             self._stop_event.set()
@@ -192,7 +192,7 @@ class Server:
         )
         try:
             self.loop.run_forever()
-        except SystemExit:
+        except (KeyboardInterrupt, SystemExit):
             pass
         finally:
             self.shutdown()


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

If ctr+c is pressed while the server is running in a command shell, a `KeyboardInterrupt` exception is raised to stop the asyncio event loop.

This commit catches that exception to exit the server normally without printing a traceback.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
