### PR TITLE
Optimize message serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 - Exit server normally when `ctrl+c` is pressed in command shell.
+- Optimize json-rpc message serialization ([#120])
 
+[#120]: https://github.com/openlawlibrary/pygls/pull/120
 
 ## [0.9.0] - 04/20/2020
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -389,8 +389,7 @@ class JsonRPCProtocol(asyncio.Protocol):
                 len(body), self.CONTENT_TYPE, self.CHARSET
             ).encode(self.CHARSET)
 
-            self.transport.write(header)
-            self.transport.write(body)
+            self.transport.write(header + body)
         except Exception:
             logger.error(traceback.format_exc())
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -379,20 +379,18 @@ class JsonRPCProtocol(asyncio.Protocol):
 
         try:
             body = json.dumps(data, default=default_serializer)
-            content_length = len(body.encode(self.CHARSET)) if body else 0
-
-            response = (
-                'Content-Length: {}\r\n'
-                'Content-Type: {}; charset={}\r\n\r\n'
-                '{}'.format(content_length,
-                            self.CONTENT_TYPE,
-                            self.CHARSET,
-                            body)
-            )
-
             logger.info('Sending data: {}'.format(body))
 
-            self.transport.write(response.encode(self.CHARSET))
+            body = body.encode(self.CHARSET)
+            header = (
+                'Content-Length: {}\r\n'
+                'Content-Type: {}; charset={}\r\n\r\n'
+            ).format(
+                len(body), self.CONTENT_TYPE, self.CHARSET
+            ).encode(self.CHARSET)
+
+            self.transport.write(header)
+            self.transport.write(body)
         except Exception:
             logger.error(traceback.format_exc())
 


### PR DESCRIPTION
This commit modifies the `JsonRPCProtocol._send_data()` method in order to avoid duplicated utf-8 encoding of body content.

Up to this commit the serialized json payload was encoded to just receive its length and once more together with the whole content header.

The `header` and `body` are created, encoded and streamed independently, now.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
