### PR TITLE
Mark deprecated rangeLength optional in TextDocumentContentChangeEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 - Exit server normally when `ctrl+c` is pressed in command shell.
+- Mark deprecated `rangeLength` optional in `TextDocumentContentChangeEvent` ([#123])
 - Optimize json-rpc message serialization ([#120])
 
+[#123]: https://github.com/openlawlibrary/pygls/pull/123
 [#120]: https://github.com/openlawlibrary/pygls/pull/120
 [#117]: https://github.com/openlawlibrary/pygls/pull/117
 

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -1188,7 +1188,10 @@ class TextDocumentClientCapabilities:
 
 
 class TextDocumentContentChangeEvent:
-    def __init__(self, range: 'Range', range_length: NumType, text: str):
+    def __init__(self,
+                 range: Optional['Range'] = None,
+                 range_length: Optional[NumType] = None,
+                 text: str = ''):
         self.range = range
         self.rangeLength = range_length
         self.text = text

--- a/pygls/types.py
+++ b/pygls/types.py
@@ -1199,7 +1199,7 @@ class TextDocumentClientCapabilities:
 
 class TextDocumentContentChangeEvent:
     def __init__(self,
-                 range: Optional['Range'] = None,
+                 range: 'Range',
                  range_length: Optional[NumType] = None,
                  text: str = ''):
         self.range = range

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -67,7 +67,7 @@ def test_document_full_edit():
     ]
 
     doc = Document('file:///uri', u''.join(old), sync_kind=TextDocumentSyncKind.FULL)
-    change = TextDocumentContentChangeEvent(text=u'print a, b')
+    change = TextDocumentContentChangeEvent(range=None, text=u'print a, b')
     doc.apply_change(change)
 
     assert doc.lines == [

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -66,6 +66,14 @@ def test_document_full_edit():
         "print a, b"
     ]
 
+    doc = Document('file:///uri', u''.join(old), sync_kind=TextDocumentSyncKind.FULL)
+    change = TextDocumentContentChangeEvent(text=u'print a, b')
+    doc.apply_change(change)
+
+    assert doc.lines == [
+        "print a, b"
+    ]
+
 
 def test_document_line_edit():
     doc = Document('file:///uri', u'itshelloworld')
@@ -89,6 +97,16 @@ def test_document_multiline_edit():
     doc = Document('file:///uri', u''.join(old), sync_kind=TextDocumentSyncKind.INCREMENTAL)
     change = TextDocumentContentChangeEvent(
         Range(Position(1, 4), Position(2, 11)), 0, u'print a, b')
+    doc.apply_change(change)
+
+    assert doc.lines == [
+        "def hello(a, b):\n",
+        "    print a, b\n"
+    ]
+
+    doc = Document('file:///uri', u''.join(old), sync_kind=TextDocumentSyncKind.INCREMENTAL)
+    change = TextDocumentContentChangeEvent(
+        range=Range(Position(1, 4), Position(2, 11)), text=u'print a, b')
     doc.apply_change(change)
 
     assert doc.lines == [


### PR DESCRIPTION
The rangeLength attribute in the TextDocumentContentChangeEvent is marked deprecated and therefore no longer enforced by pygls. If it is passed by a client, it is accepted silently, but as it is not needed for text synchronization at all, it is marked optional.

As the result the whole Document.apply_change() method can be slightly simplified.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
