### PR TITLE
Add WebSocket server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning][semver].
 ### Added
 
 - Testing against Python 3.9 ([#186])
+- Websocket server implementation `start_websocket` for LSP ([#129])
 
 ### Changed
 
 ### Fixed
+
+[#186]: https://github.com/openlawlibrary/pygls/pull/186
+[#129]: https://github.com/openlawlibrary/pygls/pull/129
 
 ## [0.10.3] - 05/05/2021
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
 - [DeathAxe](https://github.com/deathaxe)
 - [Denis Loginov](https://github.com/dinvlad)
 - [Jérome Perrin](https://github.com/perrinjerome)
+- [Matej Kašťák](https://github.com/MatejKastak)
 - [Max O'Cull](https://github.com/Maxattax97)
 - [Samuel Roeca](https://github.com/pappasam)
 - [Tomoya Tanjo](https://github.com/tom-tan)

--- a/docs/source/pages/advanced_usage.rst
+++ b/docs/source/pages/advanced_usage.rst
@@ -50,6 +50,22 @@ The code snippet below shows how to start the server in *STDIO* mode.
 
     server.start_io()
 
+WEBSOCKET
+^^^^^^^^^
+
+WEBSOCKET connections are used when you want to expose language server to
+browser based editors.
+
+The code snippet below shows how to start the server in *WEBSOCKET* mode.
+
+.. code:: python
+
+    from pygls.server import LanguageServer
+
+    server = LanguageServer()
+
+    server.start_websocket('0.0.0.0', 1234)
+
 Logging
 ~~~~~~~
 

--- a/examples/json-extension/.vscode/launch.json
+++ b/examples/json-extension/.vscode/launch.json
@@ -29,6 +29,19 @@
             "env": {
                 "PYTHONPATH": "${workspaceFolder}"
             }
+        },
+        {
+            "name": "Launch Server [WebSockets]",
+            "type": "python",
+            "request": "launch",
+            "module": "server",
+            "args": ["--ws"],
+            "justMyCode": false,
+            "python": "${command:python.interpreterPath}",
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}"
+            }
         }
     ],
     "compounds": [

--- a/examples/json-extension/server/__main__.py
+++ b/examples/json-extension/server/__main__.py
@@ -27,7 +27,11 @@ def add_arguments(parser):
 
     parser.add_argument(
         "--tcp", action="store_true",
-        help="Use TCP server instead of stdio"
+        help="Use TCP server"
+    )
+    parser.add_argument(
+        "--ws", action="store_true",
+        help="Use WebSocket server"
     )
     parser.add_argument(
         "--host", default="127.0.0.1",
@@ -46,6 +50,8 @@ def main():
 
     if args.tcp:
         json_server.start_tcp(args.host, args.port)
+    elif args.ws:
+        json_server.start_ws(args.host, args.port)
     else:
         json_server.start_io()
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -188,6 +188,8 @@ class JsonRPCProtocol(asyncio.Protocol):
         self.transport = None
         self._message_buf = []
 
+        self._send_only_data = False
+
     def __call__(self):
         return self
 
@@ -370,16 +372,19 @@ class JsonRPCProtocol(asyncio.Protocol):
 
         try:
             body = data.json(by_alias=True, exclude_unset=True)
-
             logger.info('Sending data: %s', body)
 
             body = body.encode(self.CHARSET)
-            header = (
-                f'Content-Length: {len(body)}\r\n'
-                f'Content-Type: {self.CONTENT_TYPE}; charset={self.CHARSET}\r\n\r\n'
-            ).encode(self.CHARSET)
 
-            self.transport.write(header + body)
+            if not self._send_only_data:
+                header = (
+                    f'Content-Length: {len(body)}\r\n'
+                    f'Content-Type: {self.CONTENT_TYPE}; charset={self.CHARSET}\r\n\r\n'
+                ).encode(self.CHARSET)
+
+                self.transport.write(header + body)
+            else:
+                self.transport.write(body.decode('utf-8'))
         except Exception:
             logger.error(traceback.format_exc())
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -188,7 +188,7 @@ class JsonRPCProtocol(asyncio.Protocol):
         self.transport = None
         self._message_buf = []
 
-        self._send_only_data = False
+        self._send_only_body = False
 
     def __call__(self):
         return self
@@ -375,8 +375,7 @@ class JsonRPCProtocol(asyncio.Protocol):
             logger.info('Sending data: %s', body)
 
             body = body.encode(self.CHARSET)
-
-            if not self._send_only_data:
+            if not self._send_only_body:
                 header = (
                     f'Content-Length: {len(body)}\r\n'
                     f'Content-Type: {self.CONTENT_TYPE}; charset={self.CHARSET}\r\n\r\n'

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -114,7 +114,7 @@ class WebSocketTransportAdapter:
 
     def write(self, data: Any) -> None:
         """Create a task to write specified data into a WebSocket."""
-        asyncio.create_task(self._ws.send(data))
+        asyncio.ensure_future(self._ws.send(data))
 
 
 class Server:

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -216,7 +216,7 @@ class Server:
 
     def start_tcp(self, host, port):
         """Starts TCP server."""
-        logger.info('Starting TCP server on {}:{}'.format(host, port))
+        logger.info('Starting TCP server on %s:%s', host, port)
 
         self._stop_event = Event()
         self._server = self.loop.run_until_complete(

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ exclude =
     tests.*
 
 [options.extras_require]
+ws =
+    websockets==9.*
 dev =
     bandit==1.6.0
     flake8==3.7.7

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py{36,37,38,39}
 
 [testenv]
 extras =
+    ws
     test
     dev
 commands =


### PR DESCRIPTION
## Description

Implementation of [WebSocket](https://tools.ietf.org/html/rfc6455) server. This PR allows users to start the WebSocket server on a given `host` and `port` that will "wrap" the LSP protocol. The interface is the same as other `SERVER.start_*` methods.

The main use case is to create convenient interface to interact with editors that are embedded in internet browsers (for example [Monaco LSP-client](https://github.com/TypeFox/monaco-languageclient)), this could potentially allow for broader adoption.

Related to #85 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
