### PR TITLE
Turn coroutine to async def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,15 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix `__init__()` constructors in several interface types ([#125])
 - Fix valueSet type in `SymbolKindAbstract` ([#125])
 
+### Fixed
+
+- `coroutine` deprecation warning - use async def instead ([#136])
+
 [#125]: https://github.com/openlawlibrary/pygls/pull/125
 [#123]: https://github.com/openlawlibrary/pygls/pull/123
 [#120]: https://github.com/openlawlibrary/pygls/pull/120
 [#117]: https://github.com/openlawlibrary/pygls/pull/117
+[#136]: https://github.com/openlawlibrary/pygls/pull/136
 
 ## [0.9.0] - 04/20/2020
 

--- a/pygls/feature_manager.py
+++ b/pygls/feature_manager.py
@@ -59,12 +59,14 @@ def wrap_with_server(f, server):
         return f
 
     if asyncio.iscoroutinefunction(f):
-        return asyncio.coroutine(functools.partial(f, server))
+        async def wrapped(*args, **kwargs):
+            return await f(server, *args, **kwargs)
     else:
         wrapped = functools.partial(f, server)
         if is_thread_function(f):
             assign_thread_attr(wrapped)
-        return wrapped
+
+    return wrapped
 
 
 class FeatureManager:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Turn coroutine to async def to resolve deprecation warning:

`"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead`.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
