### PR TITLE
Fix jsonrpc error handling on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix server handling of client errors ([#141])
+
 ## [0.9.1] - 09/29/2020
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 - [@augb](https://github.com/augb)
 - [Daniel Elero](https://github.com/danixeee)
+- [Daniel Miller](https://github.com/millerdev)
 - [DeathAxe](https://github.com/deathaxe)
 - [Denis Loginov](https://github.com/dinvlad)
 - [Jérome Perrin](https://github.com/perrinjerome)

--- a/pygls/exceptions.py
+++ b/pygls/exceptions.py
@@ -23,8 +23,9 @@ class JsonRpcException(Exception):
     """A class used as a base class for json rpc exceptions."""
 
     def __init__(self, message=None, code=None, data=None):
-        super().__init__()
-        self.message = message or getattr(self.__class__, 'MESSAGE')
+        message = message or getattr(self.__class__, 'MESSAGE')
+        super().__init__(message)
+        self.message = message
         self.code = code or getattr(self.__class__, 'CODE')
         self.data = data
 

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -345,7 +345,7 @@ class JsonRPCProtocol(asyncio.Protocol):
         if error is not None:
             logger.debug('Received error response to message {}: {}'
                          .format(msg_id, error))
-            future.set_exception(JsonRpcException.from_dict(error))
+            future.set_exception(JsonRpcException.from_dict(error._asdict()))
 
         logger.debug('Received result for message {}: {}'
                      .format(msg_id, result))

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -346,10 +346,10 @@ class JsonRPCProtocol(asyncio.Protocol):
             logger.debug('Received error response to message {}: {}'
                          .format(msg_id, error))
             future.set_exception(JsonRpcException.from_dict(error._asdict()))
-
-        logger.debug('Received result for message {}: {}'
-                     .format(msg_id, result))
-        future.set_result(result)
+        else:
+            logger.debug('Received result for message {}: {}'
+                         .format(msg_id, result))
+            future.set_result(result)
 
     def _procedure_handler(self, message):
         """Delegates message to handlers depending on message type."""

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,8 +15,10 @@
 # limitations under the License.                                           #
 ############################################################################
 import json
+from concurrent.futures import Future
 
 import pytest
+from pygls.exceptions import JsonRpcException
 from pygls.protocol import (JsonRPCNotification, JsonRPCRequestMessage,
                             JsonRPCResponseMessage, deserialize_message,
                             to_lsp_name)
@@ -181,6 +183,28 @@ def test_data_received_multi_message_should_handle_messages(client_server):
     messages = (dummy_message(i) for i in range(3))
     data = b''.join(messages)
     server.lsp.data_received(data)
+
+
+def test_data_received_error_should_raise_jsonrpc_error(client_server):
+    _, server = client_server
+    body = json.dumps({
+        "jsonrpc": "2.0",
+        "id": "err",
+        "error": {
+            "code": -1,
+            "message": "message for you sir",
+        },
+    })
+    message = '\r\n'.join([
+        'Content-Length: ' + str(len(body)),
+        'Content-Type: application/vscode-jsonrpc; charset=utf-8',
+        '',
+        body,
+    ]).encode("utf-8")
+    future = server.lsp._server_request_futures["err"] = Future()
+    server.lsp.data_received(message)
+    with pytest.raises(JsonRpcException, match="message for you sir"):
+        future.result()
 
 
 def test_initialize_without_capabilities_should_raise_error(client_server):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Errors received from the client are not properly converted to `JsonRpcException`, and the conversion process causes other errors on the server.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
