### PR TITLE
Lsp miscellany

### DIFF
--- a/pygls/capabilities.py
+++ b/pygls/capabilities.py
@@ -63,12 +63,12 @@ class ServerCapabilitiesBuilder:
             or TEXT_DOCUMENT_DID_CLOSE in self.features
         )
         will_save = (
-            self.client_capabilities.has_capability(
+            self.client_capabilities.get_capability(
                 'text_document.synchronization.will_save')
             and TEXT_DOCUMENT_WILL_SAVE in self.features
         )
         will_save_wait_until = (
-            self.client_capabilities.has_capability(
+            self.client_capabilities.get_capability(
                 'text_document.synchronization.will_save_wait_until')
             and TEXT_DOCUMENT_WILL_SAVE_WAIT_UNTIL in self.features
         )

--- a/pygls/lsp/types/general_messages.py
+++ b/pygls/lsp/types/general_messages.py
@@ -150,17 +150,20 @@ class ClientCapabilities(Model):
     window: Optional[WindowClientCapabilities] = None
     experimental: Optional[Any] = None
 
-    def has_capability(self, field):
+    def get_capability(self, field: str, default: Any = None) -> Any:
         """Check if ClientCapabilities has some nested value without raising
         AttributeError.
 
-        e.g. has_capability('text_document.synchronization.will_save')
+        e.g. get_capability('text_document.synchronization.will_save')
         """
-        return reduce(
-            lambda d, key: d.get(key, None) if isinstance(d, dict) else None,
-            field.split("."),
-            self.dict(),
-        )
+        try:
+            value = reduce(getattr, field.split("."), self)
+        except AttributeError:
+            return default
+
+        # If we reach the desired leaf value but it's None, return the default.
+        value = default if value is None else value
+        return value
 
 
 class InitializeParams(WorkDoneProgressParams):

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         ])
     ],
     zip_safe=False,
-    install_requires=["pydantic==1.7", "typeguard==2.10.0"],
+    install_requires=["pydantic>=1.7,<1.9", "typeguard>=2.10.0,<3"],
     extras_require={
         'dev': development,
         'docs': docs_require,


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Related to #139 (and this pull request is against that branch).

I have:

- allowed pydantic and typeguard versions to go higher.  typeguard declares that it follows semantic versioning, so 2.x should be safe.  pydantic seems to make breaking changes at minor releases; however 1.8 works just fine so I've allowed 1.7.x and 1.8.x

- tweaked `ClientCapabilities.has_capability()` along the lines I suggested in https://github.com/openlawlibrary/pygls/pull/139#issuecomment-798347921 ie added a type annotation, and allowed it to return a default value.  I've also renamed it to `get_capability()`, since it handles not only boolean values (eg `text_document.completion.completion_item.documentation_format` is a list of `MarkupKind`).