### PR TITLE
Fix pydantic Unions type conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix `pydantic` Unions type conversion ([#160])
 - Fix change_notifications type (pydantic bug) ([#158])
 
+[#160]: https://github.com/openlawlibrary/pygls/pull/160
 [#158]: https://github.com/openlawlibrary/pygls/pull/158
 
 ## [0.10.1] - 03/17/2021

--- a/pygls/lsp/types/basic_structures.py
+++ b/pygls/lsp/types/basic_structures.py
@@ -350,12 +350,6 @@ class MarkupContent(Model):
     value: str
 
 
-DocumentChangesType = Union[
-    List[TextDocumentEdit],
-    List[Union[TextDocumentEdit, CreateFile, RenameFile, DeleteFile]],
-]
-
-
 class WorkspaceEdit(Model):
     changes: Optional[Dict[str, List[TextEdit]]] = None
     document_changes: Any = None
@@ -366,7 +360,14 @@ class WorkspaceEdit(Model):
         # https://github.com/samuelcolvin/pydantic/pull/2092
 
         document_changes_val = values.get('document_changes')
-        check_type('', document_changes_val, Optional[DocumentChangesType])
+        check_type(
+            '',
+            document_changes_val,
+            Optional[Union[
+                List[TextDocumentEdit],
+                List[Union[TextDocumentEdit, CreateFile, RenameFile, DeleteFile]],
+            ]]
+        )
 
         return values
 

--- a/pygls/lsp/types/basic_structures.py
+++ b/pygls/lsp/types/basic_structures.py
@@ -28,6 +28,7 @@ import enum
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, root_validator
+from typeguard import check_type
 
 NumType = Union[int, float]
 T = TypeVar('T')
@@ -62,19 +63,31 @@ class JsonRPCNotification(JsonRpcMessage):
 
 class JsonRPCRequestMessage(JsonRpcMessage):
     """A class that represents json rpc request message."""
-    id: str
+    id: Any
     method: str
     params: Any
+
+    @root_validator
+    def check_result_or_error(cls, values):
+        # Workaround until pydantic supports StrictUnion
+        id_val = values.get('id')
+        check_type('', id_val, Union[int, str])
+
+        return values
 
 
 class JsonRPCResponseMessage(JsonRpcMessage):
     """A class that represents json rpc response message."""
-    id: str
+    id: Any
     result: Any
     error: Any
 
     @root_validator
     def check_result_or_error(cls, values):
+        # Workaround until pydantic supports StrictUnion
+        id_val = values.get('id')
+        check_type('', id_val, Union[int, str])
+
         result_val, error_val = values.get('result'), values.get('error')
 
         if result_val is not None and error_val is not None:

--- a/pygls/lsp/types/basic_structures.py
+++ b/pygls/lsp/types/basic_structures.py
@@ -70,6 +70,7 @@ class JsonRPCRequestMessage(JsonRpcMessage):
     @root_validator
     def check_result_or_error(cls, values):
         # Workaround until pydantic supports StrictUnion
+        # https://github.com/samuelcolvin/pydantic/pull/2092
         id_val = values.get('id')
         check_type('', id_val, Union[int, str])
 
@@ -85,6 +86,7 @@ class JsonRPCResponseMessage(JsonRpcMessage):
     @root_validator
     def check_result_or_error(cls, values):
         # Workaround until pydantic supports StrictUnion
+        # https://github.com/samuelcolvin/pydantic/pull/2092
         id_val = values.get('id')
         check_type('', id_val, Union[int, str])
 
@@ -356,7 +358,17 @@ DocumentChangesType = Union[
 
 class WorkspaceEdit(Model):
     changes: Optional[Dict[str, List[TextEdit]]] = None
-    document_changes: Optional[DocumentChangesType] = None
+    document_changes: Any = None
+
+    @root_validator
+    def check_result_or_error(cls, values):
+        # Workaround until pydantic supports StrictUnion
+        # https://github.com/samuelcolvin/pydantic/pull/2092
+
+        document_changes_val = values.get('document_changes')
+        check_type('', document_changes_val, Optional[DocumentChangesType])
+
+        return values
 
 
 class WorkDoneProgressBegin(Model):

--- a/tests/lsp/test_rename.py
+++ b/tests/lsp/test_rename.py
@@ -157,11 +157,7 @@ class TestRename(unittest.TestCase):
 
         assert response['documentChanges'][3]['uri'] == 'delete file'
         assert response['documentChanges'][3]['options']['ignoreIfExists'] == True
-
-        # NOTE: pydantic BUG! `response['documentChanges'][3]` is of type `CreateFile` !?!?
-        # https://github.com/samuelcolvin/pydantic/pull/2092
-        #
-        # assert response['documentChanges'][3]['options']['overwrite'] == True
+        assert response['documentChanges'][3]['options']['recursive'] == True
 
     def test_rename_return_none(self):
         response = self.client.lsp.send_request(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #159.

The reason I couldn't do this:

```python
class JsonRPCRequestMessage(JsonRpcMessage):
    """A class that represents json rpc request message."""
    id: Union[int,str]
    method: str
    params: Any
```

is that in the case of `Union`, `pydantic` tries to convert the input to the first valid type, so, if you pass `id='1'`, an object will have a field of type `int` `id=1`...

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
