### PR TITLE
Avoid unwanted "null"s in server capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Don't serialize unwanted `"null"` values in server capabilities
+
 ## [0.10.2] - 03/25/2021
 
 ### Added

--- a/pygls/capabilities.py
+++ b/pygls/capabilities.py
@@ -51,10 +51,7 @@ class ServerCapabilitiesBuilder:
 
     def _provider_options(self, feature, default=True):
         if feature in self.features:
-            if feature in self.feature_options:
-                return self.feature_options[feature]
-            else:
-                return default
+            return self.feature_options.get(feature, default)
         return None
 
     def _with_text_doc_sync(self):
@@ -92,99 +89,117 @@ class ServerCapabilitiesBuilder:
         return self
 
     def _with_completion(self):
-        self.server_cap.completion_provider = \
-            self._provider_options(COMPLETION, default=CompletionOptions())
+        value = self._provider_options(COMPLETION, default=CompletionOptions())
+        if value is not None:
+            self.server_cap.completion_provider = value
         return self
 
     def _with_hover(self):
-        self.server_cap.hover_provider = self._provider_options(HOVER)
+        value = self._provider_options(HOVER)
+        if value is not None:
+            self.server_cap.hover_provider = value
         return self
 
     def _with_signature_help(self):
-        self.server_cap.signature_help_provider = \
-            self._provider_options(SIGNATURE_HELP,
-                                   default=SignatureHelpOptions())
+        value = self._provider_options(SIGNATURE_HELP, default=SignatureHelpOptions())
+        if value is not None:
+            self.server_cap.signature_help_provider = value
         return self
 
     def _with_declaration(self):
-        self.server_cap.declaration_provider = \
-            self._provider_options(DECLARATION)
+        value = self._provider_options(DECLARATION)
+        if value is not None:
+            self.server_cap.declaration_provider = value
         return self
 
     def _with_definition(self):
-        self.server_cap.definition_provider = self._provider_options(DEFINITION)
+        value = self._provider_options(DEFINITION)
+        if value is not None:
+            self.server_cap.definition_provider = value
         return self
 
     def _with_type_definition(self):
-        self.server_cap.type_definition_provider = \
-            self._provider_options(TYPE_DEFINITION,
-                                   default=TypeDefinitionOptions())
+        value = self._provider_options(TYPE_DEFINITION, default=TypeDefinitionOptions())
+        if value is not None:
+            self.server_cap.type_definition_provider = value
         return self
 
     def _with_implementation(self):
-        self.server_cap.implementation_provider = \
-            self._provider_options(IMPLEMENTATION,
-                                   default=ImplementationOptions())
+        value = self._provider_options(IMPLEMENTATION, default=ImplementationOptions())
+        if value is not None:
+            self.server_cap.implementation_provider = value
         return self
 
     def _with_references(self):
-        self.server_cap.references_provider = self._provider_options(REFERENCES)
+        value = self._provider_options(REFERENCES)
+        if value is not None:
+            self.server_cap.references_provider = value
         return self
 
     def _with_document_highlight(self):
-        self.server_cap.document_highlight_provider = \
-            self._provider_options(DOCUMENT_HIGHLIGHT)
+        value = self._provider_options(DOCUMENT_HIGHLIGHT)
+        if value is not None:
+            self.server_cap.document_highlight_provider = value
         return self
 
     def _with_document_symbol(self):
-        self.server_cap.document_symbol_provider = \
-            self._provider_options(DOCUMENT_SYMBOL)
+        value = self._provider_options(DOCUMENT_SYMBOL)
+        if value is not None:
+            self.server_cap.document_symbol_provider = value
         return self
 
     def _with_code_action(self):
-        self.server_cap.code_action_provider = \
-            self._provider_options(CODE_ACTION)
+        value = self._provider_options(CODE_ACTION)
+        if value is not None:
+            self.server_cap.code_action_provider = value
         return self
 
     def _with_code_lens(self):
-        self.server_cap.code_lens_provider = \
-            self._provider_options(CODE_LENS,
-                                   default=CodeLensOptions())
+        value = self._provider_options(CODE_LENS, default=CodeLensOptions())
+        if value is not None:
+            self.server_cap.code_lens_provider = value
         return self
 
     def _with_document_link(self):
-        self.server_cap.document_link_provider = \
-            self._provider_options(DOCUMENT_LINK,
-                                   default=DocumentLinkOptions())
+        value = self._provider_options(DOCUMENT_LINK, default=DocumentLinkOptions())
+        if value is not None:
+            self.server_cap.document_link_provider = value
         return self
 
     def _with_color(self):
-        self.server_cap.color_provider = \
-            self._provider_options(DOCUMENT_COLOR)
+        value = self._provider_options(DOCUMENT_COLOR)
+        if value is not None:
+            self.server_cap.color_provider = value
         return self
 
     def _with_document_formatting(self):
-        self.server_cap.document_formatting_provider = \
-            self._provider_options(FORMATTING)
+        value = self._provider_options(FORMATTING)
+        if value is not None:
+            self.server_cap.document_formatting_provider = value
         return self
 
     def _with_document_range_formatting(self):
-        self.server_cap.document_range_formatting_provider = \
-            self._provider_options(RANGE_FORMATTING)
+        value = self._provider_options(RANGE_FORMATTING)
+        if value is not None:
+            self.server_cap.document_range_formatting_provider = value
         return self
 
     def _with_document_on_type_formatting(self):
-        self.server_cap.document_on_type_formatting_provider = \
-            self._provider_options(ON_TYPE_FORMATTING)
+        value = self._provider_options(ON_TYPE_FORMATTING)
+        if value is not None:
+            self.server_cap.document_on_type_formatting_provider = value
         return self
 
     def _with_rename(self):
-        self.server_cap.rename_provider = self._provider_options(RENAME)
+        value = self._provider_options(RENAME)
+        if value is not None:
+            self.server_cap.rename_provider = value
         return self
 
     def _with_folding_range(self):
-        self.server_cap.folding_range_provider = \
-            self._provider_options(FOLDING_RANGE)
+        value = self._provider_options(FOLDING_RANGE)
+        if value is not None:
+            self.server_cap.folding_range_provider = value
         return self
 
     def _with_execute_command(self):
@@ -193,13 +208,15 @@ class ServerCapabilitiesBuilder:
         return self
 
     def _with_selection_range(self):
-        self.server_cap.selection_range_provider = \
-            self._provider_options(SELECTION_RANGE)
+        value = self._provider_options(SELECTION_RANGE)
+        if value is not None:
+            self.server_cap.selection_range_provider = value
         return self
 
     def _with_workspace_symbol(self):
-        self.server_cap.workspace_symbol_provider = \
-            self._provider_options(WORKSPACE_SYMBOL)
+        value = self._provider_options(WORKSPACE_SYMBOL)
+        if value is not None:
+            self.server_cap.workspace_symbol_provider = value
         return self
 
     def _with_workspace_capabilities(self):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Avoid setting fields in server capabilities to `None`, because explicitly setting them causes pydantic to serialize them, which is not what is wanted.

See https://github.com/pappasam/jedi-language-server/issues/108

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
