### PR TITLE
Don't install the tests to site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ KEYWORDS = 'python pythonic generic language server protocol'
 LICENSE = 'Apache 2.0'
 URL = 'https://github.com/openlawlibrary/pygls/tree/master/'
 
-packages = find_packages(exclude=['tests'])
+packages = find_packages(exclude=['tests*'])
 
 print('packages:', packages)
 


### PR DESCRIPTION
Commit 8b08673 ("Don't install the tests to site-packages") added
'tests' to the exclude list, but later an 'lsp' subdirectory was added
to tests/ (d0157a5 ("Add test for code completions")). Exclude 'tests*'
to avoid installing 'tests/lsp' to site-packages.