### PR TITLE
Relax text_doc type to VersionedTextDocumentIdentifier

### DIFF
--- a/pygls/workspace.py
+++ b/pygls/workspace.py
@@ -23,7 +23,8 @@ import re
 from typing import List
 
 from pygls.lsp.types import (NumType, Position, Range, TextDocumentContentChangeEvent,
-                             TextDocumentItem, TextDocumentSyncKind, WorkspaceFolder)
+                             TextDocumentItem, TextDocumentSyncKind,
+                             VersionedTextDocumentIdentifier, WorkspaceFolder)
 from pygls.uris import to_fs_path, uri_scheme
 
 # TODO: this is not the best e.g. we capture numbers
@@ -372,7 +373,7 @@ class Workspace(object):
         return self._root_uri
 
     def update_document(self,
-                        text_doc: TextDocumentItem,
+                        text_doc: VersionedTextDocumentIdentifier,
                         change: TextDocumentContentChangeEvent):
         doc_uri = text_doc.uri
         self._docs[doc_uri].apply_change(change)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Only the `uri` and `version` attributes of `text_doc` are used. Therefore `text_doc` can be a `VersionedTextDocumentIdentifier` and does not have to be a `TextDocumentItem`.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
