### PR TITLE
Adding kind field to resource file operation types

### DIFF
--- a/pygls/lsp/types/basic_structures.py
+++ b/pygls/lsp/types/basic_structures.py
@@ -243,10 +243,12 @@ class TextEdit(Model):
     range: Range
     new_text: str
 
+
 class ResourceOperationKind(str, enum.Enum):
     Create = 'create'
     Rename = 'rename'
     Delete = 'delete'
+
 
 class CreateFileOptions(Model):
     overwrite: Optional[bool] = False

--- a/pygls/lsp/types/basic_structures.py
+++ b/pygls/lsp/types/basic_structures.py
@@ -243,6 +243,10 @@ class TextEdit(Model):
     range: Range
     new_text: str
 
+class ResourceOperationKind(str, enum.Enum):
+    Create = 'create'
+    Rename = 'rename'
+    Delete = 'delete'
 
 class CreateFileOptions(Model):
     overwrite: Optional[bool] = False
@@ -250,6 +254,7 @@ class CreateFileOptions(Model):
 
 
 class CreateFile(Model):
+    kind: ResourceOperationKind = ResourceOperationKind.Create
     uri: str
     options: Optional[CreateFileOptions] = None
 
@@ -260,6 +265,7 @@ class RenameFileOptions(Model):
 
 
 class RenameFile(Model):
+    kind: ResourceOperationKind = ResourceOperationKind.Rename
     old_uri: str
     new_uri: str
     options: Optional[RenameFileOptions] = None
@@ -271,14 +277,9 @@ class DeleteFileOptions(Model):
 
 
 class DeleteFile(Model):
+    kind: ResourceOperationKind = ResourceOperationKind.Delete
     uri: str
     options: Optional[DeleteFileOptions] = None
-
-
-class ResourceOperationKind(str, enum.Enum):
-    Create = 'create'
-    Rename = 'rename'
-    Delete = 'delete'
 
 
 class FailureHandlingKind(str, enum.Enum):

--- a/tests/lsp/test_rename.py
+++ b/tests/lsp/test_rename.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and      #
 # limitations under the License.                                           #
 ############################################################################
+from pygls.lsp.types.basic_structures import ResourceOperationKind
 import unittest
 from typing import Optional
 
@@ -75,6 +76,7 @@ class TestRename(unittest.TestCase):
                             ]
                         ),
                         CreateFile(
+                            kind=ResourceOperationKind.Create,
                             uri='create file',
                             options=CreateFileOptions(
                                 overwrite=True,
@@ -82,6 +84,7 @@ class TestRename(unittest.TestCase):
                             ),
                         ),
                         RenameFile(
+                            kind=ResourceOperationKind.Rename,
                             old_uri='rename old uri',
                             new_uri='rename new uri',
                             options=RenameFileOptions(
@@ -90,6 +93,7 @@ class TestRename(unittest.TestCase):
                             )
                         ),
                         DeleteFile(
+                            kind=ResourceOperationKind.Delete,
                             uri='delete file',
                             options=DeleteFileOptions(
                                 recursive=True,
@@ -146,15 +150,18 @@ class TestRename(unittest.TestCase):
         assert response['documentChanges'][0]['edits'][0]['range']['end']['line'] == 3
         assert response['documentChanges'][0]['edits'][0]['range']['end']['character'] == 3
 
+        assert response['documentChanges'][1]['kind'] == ResourceOperationKind.Create
         assert response['documentChanges'][1]['uri'] == 'create file'
         assert response['documentChanges'][1]['options']['ignoreIfExists'] == True
         assert response['documentChanges'][1]['options']['overwrite'] == True
 
+        assert response['documentChanges'][2]['kind'] == ResourceOperationKind.Rename
         assert response['documentChanges'][2]['newUri'] == 'rename new uri'
         assert response['documentChanges'][2]['oldUri'] == 'rename old uri'
         assert response['documentChanges'][2]['options']['ignoreIfExists'] == True
         assert response['documentChanges'][2]['options']['overwrite'] == True
 
+        assert response['documentChanges'][3]['kind'] == ResourceOperationKind.Delete
         assert response['documentChanges'][3]['uri'] == 'delete file'
         assert response['documentChanges'][3]['options']['ignoreIfExists'] == True
         assert response['documentChanges'][3]['options']['recursive'] == True


### PR DESCRIPTION
## Adds kind filed to CreateFile, RenameFile and DeleteFile

Closes #176 . Missing kind causes error in VS Code when renaming packages.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
