### PR TITLE
exit when no more data available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 - Don't serialize unwanted `"null"` values in server capabilities
+- Exit when no more input is available
 
 ## [0.10.2] - 03/25/2021
 

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -48,6 +48,8 @@ async def aio_readline(loop, executor, stop_event, rfile, proxy):
     while not stop_event.is_set() and not rfile.closed:
         # Read a header line
         header = await loop.run_in_executor(executor, rfile.readline)
+        if not header:
+            break
         message.append(header)
 
         # Extract content length if possible
@@ -62,6 +64,8 @@ async def aio_readline(loop, executor, stop_event, rfile, proxy):
 
             # Read body
             body = await loop.run_in_executor(executor, rfile.read, content_length)
+            if not body:
+                break
             message.append(body)
 
             # Pass message to language server protocol


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Fixes #173.

I agree with recent comments saying that receiving an empty header at readline tells you that you're done: per <https://docs.python.org/3/tutorial/inputoutput.html#methods-of-file-objects>

> If the end of the file has been reached, f.read() will return an empty string ('') ...
> ... if f.readline() returns an empty string, the end of the file has been reached ...

So that's what this does.

If this looks good, I wonder whether it's time for a 0.10.3 release?  There have been a handful of bug fixes that it would be nice to see published.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
