### PR TITLE
Fix missing tracebacks in async notification handlers

### DIFF
--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -240,8 +240,12 @@ class JsonRPCProtocol(asyncio.Protocol):
     def _execute_notification_callback(self, future):
         """Success callback used for coroutine notification message."""
         if future.exception():
-            error = JsonRpcInternalError.of(sys.exc_info()).to_dict()
-            logger.exception('Exception occurred in notification: "%s"', error)
+
+            try:
+                raise future.exception()
+            except Exception:
+                error = JsonRpcInternalError.of(sys.exc_info()).to_dict()
+                logger.exception('Exception occurred in notification: "%s"', error)
 
             # Revisit. Client does not support response with msg_id = None
             # https://stackoverflow.com/questions/31091376/json-rpc-2-0-allow-notifications-to-have-an-error-response


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This fixes #187.

By raising the exception stored in the future and then handling it `sys.exc_info()` is able to see the exception and provide the details which can then be logged. With this change I now see a detailed traceback in the log.
```python
ERROR:pygls.protocol:Exception occurred in notification: "{'code': -32602, 'message': 'ZeroDivisionError: division by zero', 'data': '{\'traceback\': [\'  File "/home/alex/Code/pygls/pygls/protocol.py", line 246, in _execute_notification_callback\\n    raise future.exception()\\n\', \'  File "/home/alex/Code/pygls/pygls/feature_manager.py", line 68, in wrapped\\n    return await f(server, *args, **kwargs)\\n\', \'  File "/home/alex/Code/pygls/examples/json-extension/server/server.py", line 149, in did_open\\n    x = 1 / 0\\n\']}'}"
Traceback (most recent call last):
  File "/home/alex/Code/pygls/pygls/protocol.py", line 246, in _execute_notification_callback
    raise future.exception()
  File "/home/alex/Code/pygls/pygls/feature_manager.py", line 68, in wrapped
    return await f(server, *args, **kwargs)
  File "/home/alex/Code/pygls/examples/json-extension/server/server.py", line 149, in did_open
    x = 1 / 0
ZeroDivisionError: division by zero
```

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
