### PR TITLE
remove defaults from optional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Remove defaults from all optional fields on protocol-defined types
+  - Explicitly defaulting to None was redundant; defaulting them to other values
+    made them not optional after all
+
 ### Fixed
 
 ## [0.11.0] - 06/18/2021

--- a/pygls/lsp/types/basic_structures.py
+++ b/pygls/lsp/types/basic_structures.py
@@ -54,14 +54,6 @@ class Model(BaseModel):
             'from_': 'from'
         }
 
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
-
-        # Serialize (.json()) fields that has default value which is not None
-        for name, field in self.__fields__.items():
-            if getattr(field, 'default', None) is not None:
-                self.__fields_set__.add(name)
-
 
 class JsonRpcMessage(Model):
     """A base json rpc message defined by LSP."""
@@ -238,7 +230,7 @@ class SetTraceParams(Model):
 
 class RegularExpressionsClientCapabilities(Model):
     engine: str
-    version: Optional[str] = None
+    version: Optional[str]
 
 
 class ResolveSupportClientCapabilities(Model):
@@ -249,7 +241,7 @@ class LocationLink(Model):
     target_uri: str
     target_range: Range
     target_selection_range: Range
-    origin_selection_range: Optional[Range] = None
+    origin_selection_range: Optional[Range]
 
 
 class DiagnosticSeverity(enum.IntEnum):
@@ -276,19 +268,19 @@ class CodeDescription(Model):
 class Diagnostic(Model):
     range: Range
     message: str
-    severity: Optional[DiagnosticSeverity] = None
-    code: Optional[Union[int, str]] = None
-    code_description: Optional[CodeDescription] = None
-    source: Optional[str] = None
-    related_information: Optional[List[DiagnosticRelatedInformation]] = None
-    tags: Optional[List[DiagnosticTag]] = None
-    data: Optional[Any] = None
+    severity: Optional[DiagnosticSeverity]
+    code: Optional[Union[int, str]]
+    code_description: Optional[CodeDescription]
+    source: Optional[str]
+    related_information: Optional[List[DiagnosticRelatedInformation]]
+    tags: Optional[List[DiagnosticTag]]
+    data: Optional[Any]
 
 
 class Command(Model):
     title: str
     command: str
-    arguments: Optional[List[Any]] = None
+    arguments: Optional[List[Any]]
 
 
 class TextEdit(Model):
@@ -302,8 +294,8 @@ class AnnotatedTextEdit(TextEdit):
 
 class ChangeAnnotation(Model):
     label: str
-    needs_confirmation: Optional[bool] = False
-    description: Optional[str] = None
+    needs_confirmation: Optional[bool]
+    description: Optional[str]
 
 
 class ResourceOperationKind(str, enum.Enum):
@@ -313,40 +305,40 @@ class ResourceOperationKind(str, enum.Enum):
 
 
 class CreateFileOptions(Model):
-    overwrite: Optional[bool] = False
-    ignore_if_exists: Optional[bool] = False
+    overwrite: Optional[bool]
+    ignore_if_exists: Optional[bool]
 
 
 class CreateFile(Model):
     kind: ResourceOperationKind = ResourceOperationKind.Create
     uri: str
-    options: Optional[CreateFileOptions] = None
-    annotation_id: Optional[ChangeAnnotationIdentifier] = None
+    options: Optional[CreateFileOptions]
+    annotation_id: Optional[ChangeAnnotationIdentifier]
 
 
 class RenameFileOptions(Model):
-    overwrite: Optional[bool] = False
-    ignore_if_exists: Optional[bool] = False
+    overwrite: Optional[bool]
+    ignore_if_exists: Optional[bool]
 
 
 class RenameFile(Model):
     kind: ResourceOperationKind = ResourceOperationKind.Rename
     old_uri: str
     new_uri: str
-    options: Optional[RenameFileOptions] = None
-    annotation_id: Optional[ChangeAnnotationIdentifier] = None
+    options: Optional[RenameFileOptions]
+    annotation_id: Optional[ChangeAnnotationIdentifier]
 
 
 class DeleteFileOptions(Model):
-    recursive: Optional[bool] = False
-    ignore_if_exists: Optional[bool] = False
+    recursive: Optional[bool]
+    ignore_if_exists: Optional[bool]
 
 
 class DeleteFile(Model):
     kind: ResourceOperationKind = ResourceOperationKind.Delete
     uri: str
-    options: Optional[DeleteFileOptions] = None
-    annotation_id: Optional[ChangeAnnotationIdentifier] = None
+    options: Optional[DeleteFileOptions]
+    annotation_id: Optional[ChangeAnnotationIdentifier]
 
 
 class FailureHandlingKind(str, enum.Enum):
@@ -357,15 +349,15 @@ class FailureHandlingKind(str, enum.Enum):
 
 
 class ChangeAnnotationSupport(Model):
-    groups_on_label: Optional[bool] = False
+    groups_on_label: Optional[bool]
 
 
 class WorkspaceEditClientCapabilities(Model):
-    document_changes: Optional[bool] = False
-    resource_operations: Optional[List[ResourceOperationKind]] = None
-    failure_handling: Optional[FailureHandlingKind] = None
-    normalizes_line_endings: Optional[bool] = False
-    change_annotation_support: Optional[ChangeAnnotationSupport] = None
+    document_changes: Optional[bool]
+    resource_operations: Optional[List[ResourceOperationKind]]
+    failure_handling: Optional[FailureHandlingKind]
+    normalizes_line_endings: Optional[bool]
+    change_annotation_support: Optional[ChangeAnnotationSupport]
 
 
 class TextDocumentIdentifier(Model):
@@ -398,20 +390,20 @@ class TextDocumentPositionParams(Model):
 
 
 class DocumentFilter(Model):
-    language: Optional[str] = None
-    scheme: Optional[str] = None
-    pattern: Optional[str] = None
+    language: Optional[str]
+    scheme: Optional[str]
+    pattern: Optional[str]
 
 
 DocumentSelector = List[DocumentFilter]
 
 
 class StaticRegistrationOptions(Model):
-    id: Optional[str] = None
+    id: Optional[str]
 
 
 class TextDocumentRegistrationOptions(Model):
-    document_selector: Optional[DocumentSelector] = None
+    document_selector: Optional[DocumentSelector]
 
 
 class MarkupKind(str, enum.Enum):
@@ -425,9 +417,9 @@ class MarkupContent(Model):
 
 
 class WorkspaceEdit(Model):
-    changes: Optional[Dict[str, List[TextEdit]]] = None
-    document_changes: Optional[Any] = None
-    change_annotations: Optional[Dict[ChangeAnnotationIdentifier, ChangeAnnotation]] = None
+    changes: Optional[Dict[str, List[TextEdit]]]
+    document_changes: Optional[Any]
+    change_annotations: Optional[Dict[ChangeAnnotationIdentifier, ChangeAnnotation]]
 
     @root_validator
     def check_result_or_error(cls, values):
@@ -450,21 +442,21 @@ class WorkspaceEdit(Model):
 class WorkDoneProgressBegin(Model):
     kind: str = 'begin'
     title: str
-    cancellable: Optional[bool] = False
-    message: Optional[str] = None
-    percentage: Optional[NumType] = None
+    cancellable: Optional[bool]
+    message: Optional[str]
+    percentage: Optional[NumType]
 
 
 class WorkDoneProgressReport(Model):
     kind: str = 'report'
-    cancellable: Optional[bool] = False
-    message: Optional[str] = None
-    percentage: Optional[NumType] = None
+    cancellable: Optional[bool]
+    message: Optional[str]
+    percentage: Optional[NumType]
 
 
 class WorkDoneProgressEnd(Model):
     kind: str = 'end'
-    message: Optional[str] = None
+    message: Optional[str]
 
 
 class WorkDoneProgressParams(Model):

--- a/pygls/lsp/types/client.py
+++ b/pygls/lsp/types/client.py
@@ -32,7 +32,7 @@ from pygls.lsp.types.basic_structures import Model
 class Registration(Model):
     id: str
     method: str
-    register_options: Optional[Any] = None
+    register_options: Optional[Any]
 
 
 class RegistrationParams(Model):

--- a/pygls/lsp/types/diagnostics.py
+++ b/pygls/lsp/types/diagnostics.py
@@ -30,18 +30,18 @@ from pygls.lsp.types.basic_structures import Diagnostic, DiagnosticTag, Model, N
 
 
 class PublishDiagnosticsTagSupportClientCapabilities(Model):
-    value_set: Optional[List[DiagnosticTag]] = None
+    value_set: Optional[List[DiagnosticTag]]
 
 
 class PublishDiagnosticsClientCapabilities(Model):
-    related_information: Optional[bool] = False
-    tag_support: Optional[PublishDiagnosticsTagSupportClientCapabilities] = None
-    version_support: Optional[bool] = False
-    code_description_support: Optional[bool] = False
-    data_support: Optional[bool] = False
+    related_information: Optional[bool]
+    tag_support: Optional[PublishDiagnosticsTagSupportClientCapabilities]
+    version_support: Optional[bool]
+    code_description_support: Optional[bool]
+    data_support: Optional[bool]
 
 
 class PublishDiagnosticsParams(Model):
     uri: str
     diagnostics: List[Diagnostic]
-    version: Optional[NumType] = None
+    version: Optional[NumType]

--- a/pygls/lsp/types/file_operations.py
+++ b/pygls/lsp/types/file_operations.py
@@ -36,17 +36,17 @@ class FileOperationPatternKind(str, enum.Enum):
 
 
 class FileOperationPatternOptions(Model):
-    ignore_case: Optional[bool] = False
+    ignore_case: Optional[bool]
 
 
 class FileOperationPattern(Model):
     glob: str
-    matches: Optional[FileOperationPatternKind] = None
-    options: Optional[FileOperationPatternOptions] = None
+    matches: Optional[FileOperationPatternKind]
+    options: Optional[FileOperationPatternOptions]
 
 
 class FileOperationFilter(Model):
-    scheme: Optional[str] = None
+    scheme: Optional[str]
     pattern: FileOperationPattern
 
 

--- a/pygls/lsp/types/general_messages.py
+++ b/pygls/lsp/types/general_messages.py
@@ -94,111 +94,111 @@ from pygls.lsp.types.workspace import (DidChangeConfigurationClientCapabilities,
 
 class ClientInfo(Model):
     name: str = 'unknown'
-    version: Optional[str] = None
+    version: Optional[str]
 
 
 class ServerInfo(Model):
     name: str = 'unknown'
-    version: Optional[str] = None
+    version: Optional[str]
 
 
 class TextDocumentClientCapabilities(Model):
-    synchronization: Optional[TextDocumentSyncClientCapabilities] = None
-    completion: Optional[CompletionClientCapabilities] = None
-    hover: Optional[HoverClientCapabilities] = None
-    signature_help: Optional[SignatureHelpClientCapabilities] = None
-    declaration: Optional[DeclarationClientCapabilities] = None
-    definition: Optional[DefinitionClientCapabilities] = None
-    type_definition: Optional[TypeDefinitionClientCapabilities] = None
-    implementation: Optional[ImplementationClientCapabilities] = None
-    references: Optional[ReferenceClientCapabilities] = None
-    document_highlight: Optional[DocumentHighlightClientCapabilities] = None
-    document_symbol: Optional[DocumentSymbolClientCapabilities] = None
-    code_action: Optional[CodeActionClientCapabilities] = None
-    code_lens: Optional[CodeLensClientCapabilities] = None
-    document_link: Optional[DocumentLinkClientCapabilities] = None
-    color_provider: Optional[DocumentColorClientCapabilities] = None
-    formatting: Optional[DocumentFormattingClientCapabilities] = None
-    range_formatting: Optional[DocumentRangeFormattingClientCapabilities] = None
-    on_type_formatting: Optional[DocumentOnTypeFormattingClientCapabilities] = None
-    rename: Optional[RenameClientCapabilities] = None
-    publish_diagnostics: Optional[PublishDiagnosticsClientCapabilities] = None
-    folding_range: Optional[FoldingRangeClientCapabilities] = None
-    selection_range: Optional[SelectionRangeClientCapabilities] = None
-    linked_editing_range: Optional[LinkedEditingRangeClientCapabilities] = None
-    call_hierarchy: Optional[CallHierarchyClientCapabilities] = None
-    semantic_tokens: Optional[SemanticTokensClientCapabilities] = None
-    moniker: Optional[MonikerClientCapabilities] = None
+    synchronization: Optional[TextDocumentSyncClientCapabilities]
+    completion: Optional[CompletionClientCapabilities]
+    hover: Optional[HoverClientCapabilities]
+    signature_help: Optional[SignatureHelpClientCapabilities]
+    declaration: Optional[DeclarationClientCapabilities]
+    definition: Optional[DefinitionClientCapabilities]
+    type_definition: Optional[TypeDefinitionClientCapabilities]
+    implementation: Optional[ImplementationClientCapabilities]
+    references: Optional[ReferenceClientCapabilities]
+    document_highlight: Optional[DocumentHighlightClientCapabilities]
+    document_symbol: Optional[DocumentSymbolClientCapabilities]
+    code_action: Optional[CodeActionClientCapabilities]
+    code_lens: Optional[CodeLensClientCapabilities]
+    document_link: Optional[DocumentLinkClientCapabilities]
+    color_provider: Optional[DocumentColorClientCapabilities]
+    formatting: Optional[DocumentFormattingClientCapabilities]
+    range_formatting: Optional[DocumentRangeFormattingClientCapabilities]
+    on_type_formatting: Optional[DocumentOnTypeFormattingClientCapabilities]
+    rename: Optional[RenameClientCapabilities]
+    publish_diagnostics: Optional[PublishDiagnosticsClientCapabilities]
+    folding_range: Optional[FoldingRangeClientCapabilities]
+    selection_range: Optional[SelectionRangeClientCapabilities]
+    linked_editing_range: Optional[LinkedEditingRangeClientCapabilities]
+    call_hierarchy: Optional[CallHierarchyClientCapabilities]
+    semantic_tokens: Optional[SemanticTokensClientCapabilities]
+    moniker: Optional[MonikerClientCapabilities]
 
 
 class FileOperationsClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    did_create: Optional[bool] = False
-    will_create: Optional[bool] = False
-    did_rename: Optional[bool] = False
-    will_rename: Optional[bool] = False
-    did_delete: Optional[bool] = False
-    will_delete: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    did_create: Optional[bool]
+    will_create: Optional[bool]
+    did_rename: Optional[bool]
+    will_rename: Optional[bool]
+    did_delete: Optional[bool]
+    will_delete: Optional[bool]
 
 
 class WorkspaceClientCapabilities(Model):
-    apply_edit: Optional[bool] = False
-    workspace_edit: Optional[WorkspaceEditClientCapabilities] = None
-    did_change_configuration: Optional[DidChangeConfigurationClientCapabilities] = None
-    did_change_watched_files: Optional[DidChangeWatchedFilesClientCapabilities] = None
-    symbol: Optional[WorkspaceSymbolClientCapabilities] = None
-    execute_command: Optional[ExecuteCommandClientCapabilities] = None
-    workspace_folders: Optional[bool] = False
-    configuration: Optional[bool] = False
-    semantic_tokens: Optional[SemanticTokensWorkspaceClientCapabilities] = None
-    code_lens: Optional[CodeLensWorkspaceClientCapabilities] = None
-    file_operations: Optional[FileOperationsClientCapabilities] = None
+    apply_edit: Optional[bool]
+    workspace_edit: Optional[WorkspaceEditClientCapabilities]
+    did_change_configuration: Optional[DidChangeConfigurationClientCapabilities]
+    did_change_watched_files: Optional[DidChangeWatchedFilesClientCapabilities]
+    symbol: Optional[WorkspaceSymbolClientCapabilities]
+    execute_command: Optional[ExecuteCommandClientCapabilities]
+    workspace_folders: Optional[bool]
+    configuration: Optional[bool]
+    semantic_tokens: Optional[SemanticTokensWorkspaceClientCapabilities]
+    code_lens: Optional[CodeLensWorkspaceClientCapabilities]
+    file_operations: Optional[FileOperationsClientCapabilities]
 
 
 class WindowClientCapabilities(Model):
-    work_done_progress: Optional[bool] = False
-    show_message: Optional[ShowMessageRequestClientCapabilities] = None
-    show_document: Optional[ShowDocumentClientCapabilities] = None
+    work_done_progress: Optional[bool]
+    show_message: Optional[ShowMessageRequestClientCapabilities]
+    show_document: Optional[ShowDocumentClientCapabilities]
 
 
 class MarkdownClientCapabilities(Model):
     parser: str
-    version: Optional[str] = None
+    version: Optional[str]
 
 
 class GeneralClientCapabilities(Model):
-    regular_expressions: Optional[RegularExpressionsClientCapabilities] = None
-    markdown: Optional[MarkdownClientCapabilities] = None
+    regular_expressions: Optional[RegularExpressionsClientCapabilities]
+    markdown: Optional[MarkdownClientCapabilities]
 
 
 class TextDocumentSyncOptionsServerCapabilities(Model):
-    open_close: Optional[bool] = False
-    change: Optional[TextDocumentSyncKind] = TextDocumentSyncKind.NONE
-    will_save: Optional[bool] = False
-    will_save_wait_until: Optional[bool] = False
-    save: Optional[Union[bool, SaveOptions]] = None
+    open_close: Optional[bool]
+    change: Optional[TextDocumentSyncKind]
+    will_save: Optional[bool]
+    will_save_wait_until: Optional[bool]
+    save: Optional[Union[bool, SaveOptions]]
 
 
 class WorkspaceFileOperationsServerCapabilities(Model):
-    did_create: Optional[FileOperationRegistrationOptions] = None
-    will_create: Optional[FileOperationRegistrationOptions] = None
-    did_rename: Optional[FileOperationRegistrationOptions] = None
-    will_rename: Optional[FileOperationRegistrationOptions] = None
-    did_delete: Optional[FileOperationRegistrationOptions] = None
-    will_delete: Optional[FileOperationRegistrationOptions] = None
+    did_create: Optional[FileOperationRegistrationOptions]
+    will_create: Optional[FileOperationRegistrationOptions]
+    did_rename: Optional[FileOperationRegistrationOptions]
+    will_rename: Optional[FileOperationRegistrationOptions]
+    did_delete: Optional[FileOperationRegistrationOptions]
+    will_delete: Optional[FileOperationRegistrationOptions]
 
 
 class WorkspaceServerCapabilities(Model):
-    workspace_folders: Optional[WorkspaceFoldersServerCapabilities] = None
-    file_operations: Optional[WorkspaceFileOperationsServerCapabilities] = None
+    workspace_folders: Optional[WorkspaceFoldersServerCapabilities]
+    file_operations: Optional[WorkspaceFileOperationsServerCapabilities]
 
 
 class ClientCapabilities(Model):
-    workspace: Optional[WorkspaceClientCapabilities] = None
-    text_document: Optional[TextDocumentClientCapabilities] = None
-    window: Optional[WindowClientCapabilities] = None
-    general: Optional[GeneralClientCapabilities] = None
-    experimental: Optional[Any] = None
+    workspace: Optional[WorkspaceClientCapabilities]
+    text_document: Optional[TextDocumentClientCapabilities]
+    window: Optional[WindowClientCapabilities]
+    general: Optional[GeneralClientCapabilities]
+    experimental: Optional[Any]
 
     def get_capability(self, field: str, default: Any = None) -> Any:
         """Check if ClientCapabilities has some nested value without raising
@@ -217,63 +217,63 @@ class ClientCapabilities(Model):
 
 
 class InitializeParams(WorkDoneProgressParams):
-    process_id: Optional[int] = None
-    root_uri: Optional[str] = None
+    process_id: Optional[int]
+    root_uri: Optional[str]
     capabilities: ClientCapabilities
-    client_info: Optional[ClientInfo] = None
-    locale: Optional[str] = None
-    root_path: Optional[str] = None
-    initialization_options: Optional[Any] = None
-    trace: Optional[Trace] = Trace.Off
-    workspace_folders: Optional[List[WorkspaceFolder]] = None
+    client_info: Optional[ClientInfo]
+    locale: Optional[str]
+    root_path: Optional[str]
+    initialization_options: Optional[Any]
+    trace: Optional[Trace]
+    workspace_folders: Optional[List[WorkspaceFolder]]
 
 
 class ServerCapabilities(Model):
-    text_document_sync: Optional[Union[TextDocumentSyncOptionsServerCapabilities, NumType]] = None
-    completion_provider: Optional[CompletionOptions] = None
-    hover_provider: Optional[Union[bool, HoverOptions]] = None
-    signature_help_provider: Optional[SignatureHelpOptions] = None
+    text_document_sync: Optional[Union[TextDocumentSyncOptionsServerCapabilities, NumType]]
+    completion_provider: Optional[CompletionOptions]
+    hover_provider: Optional[Union[bool, HoverOptions]]
+    signature_help_provider: Optional[SignatureHelpOptions]
     declaration_provider: Optional[Union[bool, DeclarationOptions,
-                                         DeclarationRegistrationOptions]] = None
-    definition_provider: Optional[Union[bool, DefinitionOptions]] = None
+                                         DeclarationRegistrationOptions]]
+    definition_provider: Optional[Union[bool, DefinitionOptions]]
     type_definition_provider: Optional[Union[bool, TypeDefinitionOptions,
-                                             TypeDefinitionRegistrationOptions]] = None
+                                             TypeDefinitionRegistrationOptions]]
     implementation_provider: Optional[Union[bool, ImplementationOptions,
-                                            ImplementationRegistrationOptions]] = None
-    references_provider: Optional[Union[bool, ReferenceOptions]] = None
-    document_highlight_provider: Optional[Union[bool, DocumentHighlightOptions]] = None
-    document_symbol_provider: Optional[Union[bool, DocumentSymbolOptions]] = None
-    code_action_provider: Optional[Union[bool, CodeActionOptions]] = None
-    code_lens_provider: Optional[CodeLensOptions] = None
-    document_link_provider: Optional[DocumentLinkOptions] = None
+                                            ImplementationRegistrationOptions]]
+    references_provider: Optional[Union[bool, ReferenceOptions]]
+    document_highlight_provider: Optional[Union[bool, DocumentHighlightOptions]]
+    document_symbol_provider: Optional[Union[bool, DocumentSymbolOptions]]
+    code_action_provider: Optional[Union[bool, CodeActionOptions]]
+    code_lens_provider: Optional[CodeLensOptions]
+    document_link_provider: Optional[DocumentLinkOptions]
     color_provider: Optional[Union[bool, DocumentColorOptions,
-                                   DocumentColorRegistrationOptions]] = None
-    document_formatting_provider: Optional[Union[bool, DocumentFormattingOptions]] = None
+                                   DocumentColorRegistrationOptions]]
+    document_formatting_provider: Optional[Union[bool, DocumentFormattingOptions]]
     document_range_formatting_provider: Optional[Union[bool,
-                                                       DocumentRangeFormattingOptions]] = None
-    document_on_type_formatting_provider: Optional[DocumentOnTypeFormattingOptions] = None
-    rename_provider: Optional[Union[bool, RenameOptions]] = None
+                                                       DocumentRangeFormattingOptions]]
+    document_on_type_formatting_provider: Optional[DocumentOnTypeFormattingOptions]
+    rename_provider: Optional[Union[bool, RenameOptions]]
     folding_range_provider: Optional[Union[bool, FoldingRangeOptions,
-                                           FoldingRangeRegistrationOptions]] = None
-    execute_command_provider: Optional[ExecuteCommandOptions] = None
+                                           FoldingRangeRegistrationOptions]]
+    execute_command_provider: Optional[ExecuteCommandOptions]
     selection_range_provider: Optional[Union[bool, SelectionRangeOptions,
-                                             SelectionRangeRegistrationOptions]] = None
+                                             SelectionRangeRegistrationOptions]]
     linked_editing_range_provider: Optional[Union[bool, LinkedEditingRangeOptions,
-                                                  LinkedEditingRangeRegistrationOptions]] = None
+                                                  LinkedEditingRangeRegistrationOptions]]
     call_hierarchy_provider: Optional[Union[bool, CallHierarchyOptions,
-                                            CallHierarchyRegistrationOptions]] = None
+                                            CallHierarchyRegistrationOptions]]
     semantic_tokens_provider: Optional[Union[SemanticTokensOptions,
-                                             SemanticTokensRegistrationOptions]] = None
+                                             SemanticTokensRegistrationOptions]]
     moniker_provider: Optional[Union[bool, MonikerOptions,
-                                     MonikerRegistrationOptions]] = None
-    workspace_symbol_provider: Optional[bool] = None
-    workspace: Optional[WorkspaceServerCapabilities] = None
-    experimental: Optional[Any] = None
+                                     MonikerRegistrationOptions]]
+    workspace_symbol_provider: Optional[bool]
+    workspace: Optional[WorkspaceServerCapabilities]
+    experimental: Optional[Any]
 
 
 class InitializeResult(Model):
     capabilities: ServerCapabilities
-    server_info: Optional[ServerInfo] = None
+    server_info: Optional[ServerInfo]
 
 
 class InitializedParams(Model):

--- a/pygls/lsp/types/general_messages.py
+++ b/pygls/lsp/types/general_messages.py
@@ -93,12 +93,12 @@ from pygls.lsp.types.workspace import (DidChangeConfigurationClientCapabilities,
 
 
 class ClientInfo(Model):
-    name: str = 'unknown'
+    name: str
     version: Optional[str]
 
 
 class ServerInfo(Model):
-    name: str = 'unknown'
+    name: str
     version: Optional[str]
 
 

--- a/pygls/lsp/types/language_features/call_hierarchy.py
+++ b/pygls/lsp/types/language_features/call_hierarchy.py
@@ -35,7 +35,7 @@ from pygls.lsp.types.language_features.document_symbol import SymbolKind, Symbol
 
 
 class CallHierarchyClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class CallHierarchyOptions(WorkDoneProgressOptions):
@@ -58,9 +58,9 @@ class CallHierarchyItem(Model):
     uri: str
     range: Range
     selection_range: Range
-    tags: Optional[List[SymbolTag]] = None
-    detail: Optional[str] = None
-    data: Optional[Any] = None
+    tags: Optional[List[SymbolTag]]
+    detail: Optional[str]
+    data: Optional[Any]
 
 
 class CallHierarchyIncomingCallsParams(WorkDoneProgressParams, PartialResultParams):

--- a/pygls/lsp/types/language_features/code_action.py
+++ b/pygls/lsp/types/language_features/code_action.py
@@ -47,26 +47,26 @@ class CodeActionKind(str, enum.Enum):
 
 
 class CodeActionLiteralSupportActionKindClientCapabilities(Model):
-    value_set: Optional[List[Union[str, CodeActionKind]]] = None
+    value_set: Optional[List[Union[str, CodeActionKind]]]
 
 
 class CodeActionLiteralSupportClientCapabilities(Model):
-    code_action_kind: Optional[CodeActionLiteralSupportActionKindClientCapabilities] = None
+    code_action_kind: Optional[CodeActionLiteralSupportActionKindClientCapabilities]
 
 
 class CodeActionClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    code_action_literal_support: Optional[CodeActionLiteralSupportClientCapabilities] = None
-    is_preferred_support: Optional[bool] = False
-    disabled_support: Optional[bool] = False
-    data_support: Optional[bool] = False
-    resolve_support: Optional[ResolveSupportClientCapabilities] = None
-    honors_change_annotations: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    code_action_literal_support: Optional[CodeActionLiteralSupportClientCapabilities]
+    is_preferred_support: Optional[bool]
+    disabled_support: Optional[bool]
+    data_support: Optional[bool]
+    resolve_support: Optional[ResolveSupportClientCapabilities]
+    honors_change_annotations: Optional[bool]
 
 
 class CodeActionOptions(WorkDoneProgressOptions):
-    code_action_kinds: Optional[List[CodeActionKind]] = None
-    resolve_provider: Optional[bool] = False
+    code_action_kinds: Optional[List[CodeActionKind]]
+    resolve_provider: Optional[bool]
 
 
 class CodeActionRegistrationOptions(TextDocumentRegistrationOptions, CodeActionOptions):
@@ -75,7 +75,7 @@ class CodeActionRegistrationOptions(TextDocumentRegistrationOptions, CodeActionO
 
 class CodeActionContext(Model):
     diagnostics: List[Diagnostic]
-    only: Optional[List[CodeActionKind]] = None
+    only: Optional[List[CodeActionKind]]
 
 
 class CodeActionParams(WorkDoneProgressParams, PartialResultParams):
@@ -90,10 +90,10 @@ class CodeActionDisabled(Model):
 
 class CodeAction(Model):
     title: str
-    kind: Optional[CodeActionKind] = None
-    diagnostics: Optional[List[Diagnostic]] = None
-    is_preferred: Optional[bool] = None
-    disabled: Optional[CodeActionDisabled] = None
-    edit: Optional[WorkspaceEdit] = None
-    command: Optional[Command] = None
-    data: Optional[Any] = None
+    kind: Optional[CodeActionKind]
+    diagnostics: Optional[List[Diagnostic]]
+    is_preferred: Optional[bool]
+    disabled: Optional[CodeActionDisabled]
+    edit: Optional[WorkspaceEdit]
+    command: Optional[Command]
+    data: Optional[Any]

--- a/pygls/lsp/types/language_features/code_lens.py
+++ b/pygls/lsp/types/language_features/code_lens.py
@@ -32,15 +32,15 @@ from pygls.lsp.types.basic_structures import (Command, Model, PartialResultParam
 
 
 class CodeLensClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class CodeLensWorkspaceClientCapabilities(Model):
-    refresh_support: Optional[bool] = False
+    refresh_support: Optional[bool]
 
 
 class CodeLensOptions(WorkDoneProgressOptions):
-    resolve_provider: Optional[bool] = False
+    resolve_provider: Optional[bool]
 
 
 class CodeLensParams(WorkDoneProgressParams, PartialResultParams):
@@ -49,5 +49,5 @@ class CodeLensParams(WorkDoneProgressParams, PartialResultParams):
 
 class CodeLens(Model):
     range: Range
-    command: Optional[Command] = None
-    data: Optional[Any] = None
+    command: Optional[Command]
+    data: Optional[Any]

--- a/pygls/lsp/types/language_features/color_presentation.py
+++ b/pygls/lsp/types/language_features/color_presentation.py
@@ -40,5 +40,5 @@ class ColorPresentationParams(WorkDoneProgressParams, PartialResultParams):
 
 class ColorPresentation(Model):
     label: str
-    text_edit: Optional[TextEdit] = None
-    additional_text_edits: Optional[List[TextEdit]] = None
+    text_edit: Optional[TextEdit]
+    additional_text_edits: Optional[List[TextEdit]]

--- a/pygls/lsp/types/language_features/completion.py
+++ b/pygls/lsp/types/language_features/completion.py
@@ -156,7 +156,7 @@ class CompletionItem(Model):
 
 class CompletionList(Model):
     is_incomplete: bool
-    items: List[CompletionItem] = []
+    items: List[CompletionItem]
 
     def add_item(self, completion_item):
         self.items.append(completion_item)

--- a/pygls/lsp/types/language_features/completion.py
+++ b/pygls/lsp/types/language_features/completion.py
@@ -42,7 +42,7 @@ class CompletionTriggerKind(enum.IntEnum):
 
 class CompletionContext(Model):
     trigger_kind: CompletionTriggerKind
-    trigger_character: Optional[str] = None
+    trigger_character: Optional[str]
 
 
 class InsertTextFormat(enum.IntEnum):
@@ -83,21 +83,21 @@ class CompletionItemKind(enum.IntEnum):
 
 
 class CompletionOptions(WorkDoneProgressOptions):
-    trigger_characters: Optional[List[str]] = None
-    all_commit_characters: Optional[List[str]] = None
-    resolve_provider: Optional[bool] = False
+    trigger_characters: Optional[List[str]]
+    all_commit_characters: Optional[List[str]]
+    resolve_provider: Optional[bool]
 
 
 class CompletionParams(TextDocumentPositionParams, WorkDoneProgressParams, PartialResultParams):
-    context: Optional['CompletionContext'] = None
+    context: Optional['CompletionContext']
 
 
 class CompletionItemKindClientCapabilities(Model):
-    value_set: Optional[List[CompletionItemKind]] = None
+    value_set: Optional[List[CompletionItemKind]]
 
 
 class CompletionTagSupportClientCapabilities(Model):
-    value_set: Optional[List[CompletionItemTag]] = None
+    value_set: Optional[List[CompletionItemTag]]
 
 
 class InsertTextMode(enum.IntEnum):
@@ -110,22 +110,22 @@ class InsertTextModeSupportClientCapabilities(Model):
 
 
 class CompletionItemClientCapabilities(Model):
-    snippet_support: Optional[bool] = False
-    commit_characters_support: Optional[bool] = False
-    documentation_format: Optional[List[MarkupKind]] = None
-    deprecated_support: Optional[bool] = False
-    preselect_support: Optional[bool] = False
-    tag_support: Optional[CompletionTagSupportClientCapabilities] = None
-    insert_replace_support: Optional[bool] = False
-    resolve_support: Optional[ResolveSupportClientCapabilities] = None
-    insert_text_mode_support: Optional[InsertTextModeSupportClientCapabilities] = None
+    snippet_support: Optional[bool]
+    commit_characters_support: Optional[bool]
+    documentation_format: Optional[List[MarkupKind]]
+    deprecated_support: Optional[bool]
+    preselect_support: Optional[bool]
+    tag_support: Optional[CompletionTagSupportClientCapabilities]
+    insert_replace_support: Optional[bool]
+    resolve_support: Optional[ResolveSupportClientCapabilities]
+    insert_text_mode_support: Optional[InsertTextModeSupportClientCapabilities]
 
 
 class CompletionClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    completion_item: Optional[CompletionItemClientCapabilities] = None
-    completion_item_kind: Optional[CompletionItemKindClientCapabilities] = None
-    context_support: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    completion_item: Optional[CompletionItemClientCapabilities]
+    completion_item_kind: Optional[CompletionItemKindClientCapabilities]
+    context_support: Optional[bool]
 
 
 class InsertReplaceEdit(Model):
@@ -136,22 +136,22 @@ class InsertReplaceEdit(Model):
 
 class CompletionItem(Model):
     label: str
-    kind: Optional[CompletionItemKind] = None
-    tags: Optional[List[CompletionItemTag]] = None
-    detail: Optional[str] = None
-    documentation: Optional[Union[str, MarkupContent]] = None
-    deprecated: Optional[bool] = False
-    preselect: Optional[bool] = False
-    sort_text: Optional[str] = None
-    filter_text: Optional[str] = None
-    insert_text: Optional[str] = None
-    insert_text_format: Optional[InsertTextFormat] = None
-    insert_text_mode: Optional[InsertTextMode] = None
-    text_edit: Optional[Union[TextEdit, InsertReplaceEdit]] = None
-    additional_text_edits: Optional[List[TextEdit]] = None
-    commit_characters: Optional[List[str]] = None
-    command: Optional[Command] = None
-    data: Optional[Any] = None
+    kind: Optional[CompletionItemKind]
+    tags: Optional[List[CompletionItemTag]]
+    detail: Optional[str]
+    documentation: Optional[Union[str, MarkupContent]]
+    deprecated: Optional[bool]
+    preselect: Optional[bool]
+    sort_text: Optional[str]
+    filter_text: Optional[str]
+    insert_text: Optional[str]
+    insert_text_format: Optional[InsertTextFormat]
+    insert_text_mode: Optional[InsertTextMode]
+    text_edit: Optional[Union[TextEdit, InsertReplaceEdit]]
+    additional_text_edits: Optional[List[TextEdit]]
+    commit_characters: Optional[List[str]]
+    command: Optional[Command]
+    data: Optional[Any]
 
 
 class CompletionList(Model):

--- a/pygls/lsp/types/language_features/declaration.py
+++ b/pygls/lsp/types/language_features/declaration.py
@@ -33,8 +33,8 @@ from pygls.lsp.types.basic_structures import (Model, StaticRegistrationOptions,
 
 
 class DeclarationClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    link_support: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    link_support: Optional[bool]
 
 
 class DeclarationOptions(WorkDoneProgressOptions):

--- a/pygls/lsp/types/language_features/definition.py
+++ b/pygls/lsp/types/language_features/definition.py
@@ -31,8 +31,8 @@ from pygls.lsp.types.basic_structures import (Model, TextDocumentPositionParams,
 
 
 class DefinitionClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    link_support: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    link_support: Optional[bool]
 
 
 class DefinitionOptions(WorkDoneProgressOptions):

--- a/pygls/lsp/types/language_features/document_color.py
+++ b/pygls/lsp/types/language_features/document_color.py
@@ -33,7 +33,7 @@ from pygls.lsp.types.basic_structures import (Model, PartialResultParams, Range,
 
 
 class DocumentColorClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class DocumentColorOptions(WorkDoneProgressOptions):

--- a/pygls/lsp/types/language_features/document_highlight.py
+++ b/pygls/lsp/types/language_features/document_highlight.py
@@ -34,7 +34,7 @@ from pygls.lsp.types.basic_structures import (Model, PartialResultParams, Range,
 
 
 class DocumentHighlightClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class DocumentHighlightOptions(WorkDoneProgressOptions):
@@ -57,4 +57,4 @@ class DocumentHighlightKind(enum.IntEnum):
 
 class DocumentHighlight(Model):
     range: Range
-    kind: Optional[DocumentHighlightKind] = DocumentHighlightKind.Text
+    kind: Optional[DocumentHighlightKind]

--- a/pygls/lsp/types/language_features/document_link.py
+++ b/pygls/lsp/types/language_features/document_link.py
@@ -32,12 +32,12 @@ from pygls.lsp.types.basic_structures import (Model, PartialResultParams, Range,
 
 
 class DocumentLinkClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    tooltip_support: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    tooltip_support: Optional[bool]
 
 
 class DocumentLinkOptions(WorkDoneProgressOptions):
-    resolve_provider: Optional[bool] = False
+    resolve_provider: Optional[bool]
 
 
 class DocumentLinkParams(WorkDoneProgressParams, PartialResultParams):
@@ -46,6 +46,6 @@ class DocumentLinkParams(WorkDoneProgressParams, PartialResultParams):
 
 class DocumentLink(Model):
     range: Range
-    target: Optional[str] = None
-    tooltip: Optional[str] = None
-    data: Optional[Any] = None
+    target: Optional[str]
+    tooltip: Optional[str]
+    data: Optional[Any]

--- a/pygls/lsp/types/language_features/document_symbol.py
+++ b/pygls/lsp/types/language_features/document_symbol.py
@@ -66,7 +66,7 @@ class SymbolTag(enum.IntEnum):
 
 
 class WorkspaceCapabilitiesSymbolKind(Model):
-    value_set: Optional[List[SymbolKind]] = None
+    value_set: Optional[List[SymbolKind]]
 
 
 class WorkspaceCapabilitiesTagSupport(Model):
@@ -78,15 +78,15 @@ class DocumentSymbolCapabilitiesTagSupport(Model):
 
 
 class DocumentSymbolClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    symbol_kind: Optional[WorkspaceCapabilitiesSymbolKind] = None
-    hierarchical_document_symbol_support: Optional[bool] = False
-    tag_support: Optional[WorkspaceCapabilitiesTagSupport] = None
-    label_support: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    symbol_kind: Optional[WorkspaceCapabilitiesSymbolKind]
+    hierarchical_document_symbol_support: Optional[bool]
+    tag_support: Optional[WorkspaceCapabilitiesTagSupport]
+    label_support: Optional[bool]
 
 
 class DocumentSymbolOptions(WorkDoneProgressOptions):
-    label: Optional[str] = None
+    label: Optional[str]
 
 
 class DocumentSymbolParams(WorkDoneProgressParams, PartialResultParams):
@@ -98,10 +98,10 @@ class DocumentSymbol(Model):
     kind: SymbolKind
     range: Range
     selection_range: Range
-    detail: Optional[str] = None
-    children: Optional[List['DocumentSymbol']] = None
-    tags: Optional[List[SymbolTag]] = None
-    deprecated: Optional[bool] = False
+    detail: Optional[str]
+    children: Optional[List['DocumentSymbol']]
+    tags: Optional[List[SymbolTag]]
+    deprecated: Optional[bool]
 
 
 DocumentSymbol.update_forward_refs()
@@ -111,6 +111,6 @@ class SymbolInformation(Model):
     name: str
     kind: SymbolKind
     location: Location
-    container_name: Optional[str] = None
-    tags: Optional[List[SymbolTag]] = None
-    deprecated: Optional[bool] = False
+    container_name: Optional[str]
+    tags: Optional[List[SymbolTag]]
+    deprecated: Optional[bool]

--- a/pygls/lsp/types/language_features/folding_range.py
+++ b/pygls/lsp/types/language_features/folding_range.py
@@ -34,9 +34,9 @@ from pygls.lsp.types.basic_structures import (Model, NumType, PartialResultParam
 
 
 class FoldingRangeClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    range_limit: Optional[NumType] = None
-    line_folding_only: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    range_limit: Optional[NumType]
+    line_folding_only: Optional[bool]
 
 
 class FoldingRangeOptions(WorkDoneProgressOptions):
@@ -62,6 +62,6 @@ class FoldingRangeKind(str, enum.Enum):
 class FoldingRange(Model):
     start_line: int
     end_line: int
-    start_character: Optional[int] = None
-    end_character: Optional[int] = None
-    kind: Optional[FoldingRangeKind] = None
+    start_character: Optional[int]
+    end_character: Optional[int]
+    kind: Optional[FoldingRangeKind]

--- a/pygls/lsp/types/language_features/formatting.py
+++ b/pygls/lsp/types/language_features/formatting.py
@@ -31,7 +31,7 @@ from pygls.lsp.types.basic_structures import (Model, TextDocumentIdentifier,
 
 
 class DocumentFormattingClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class DocumentFormattingOptions(WorkDoneProgressOptions):
@@ -41,9 +41,9 @@ class DocumentFormattingOptions(WorkDoneProgressOptions):
 class FormattingOptions(Model):
     tab_size: int
     insert_spaces: bool
-    trim_trailing_whitespace: Optional[bool] = False
-    insert_final_newline: Optional[bool] = False
-    trim_final_newlines: Optional[bool] = False
+    trim_trailing_whitespace: Optional[bool]
+    insert_final_newline: Optional[bool]
+    trim_final_newlines: Optional[bool]
 
 
 class DocumentFormattingParams(WorkDoneProgressParams):

--- a/pygls/lsp/types/language_features/hover.py
+++ b/pygls/lsp/types/language_features/hover.py
@@ -32,8 +32,8 @@ from pygls.lsp.types.basic_structures import (MarkupContent, MarkupKind, Model, 
 
 
 class HoverClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    content_format: Optional[List[MarkupKind]] = None
+    dynamic_registration: Optional[bool]
+    content_format: Optional[List[MarkupKind]]
 
 
 class HoverOptions(WorkDoneProgressOptions):
@@ -54,4 +54,4 @@ MarkedStringType = Union[str, MarkedString]
 
 class Hover(Model):
     contents: Union[MarkedStringType, List[MarkedStringType], MarkupContent]
-    range: Optional[Range] = None
+    range: Optional[Range]

--- a/pygls/lsp/types/language_features/implementation.py
+++ b/pygls/lsp/types/language_features/implementation.py
@@ -34,8 +34,8 @@ from pygls.lsp.types.basic_structures import (Model, PartialResultParams,
 
 
 class ImplementationClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    link_support: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    link_support: Optional[bool]
 
 
 class ImplementationOptions(WorkDoneProgressOptions):

--- a/pygls/lsp/types/language_features/linked_editing_range.py
+++ b/pygls/lsp/types/language_features/linked_editing_range.py
@@ -33,7 +33,7 @@ from pygls.lsp.types.basic_structures import (Model, Range, StaticRegistrationOp
 
 
 class LinkedEditingRangeClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class LinkedEditingRangeOptions(WorkDoneProgressOptions):
@@ -50,4 +50,4 @@ class LinkedEditingRangeParams(TextDocumentPositionParams, WorkDoneProgressParam
 
 class LinkedEditingRanges(Model):
     ranges: List[Range]
-    word_pattern: Optional[str] = None
+    word_pattern: Optional[str]

--- a/pygls/lsp/types/language_features/monikers.py
+++ b/pygls/lsp/types/language_features/monikers.py
@@ -34,7 +34,7 @@ from pygls.lsp.types.basic_structures import (Model, PartialResultParams,
 
 
 class MonikerClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class MonikerOptions(WorkDoneProgressOptions):
@@ -67,4 +67,4 @@ class Moniker(Model):
     scheme: str
     identifier: str
     unique: UniquenessLevel
-    kind: Optional[MonikerKind] = None
+    kind: Optional[MonikerKind]

--- a/pygls/lsp/types/language_features/on_type_formatting.py
+++ b/pygls/lsp/types/language_features/on_type_formatting.py
@@ -32,12 +32,12 @@ from pygls.lsp.types.language_features.formatting import FormattingOptions
 
 
 class DocumentOnTypeFormattingClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class DocumentOnTypeFormattingOptions(WorkDoneProgressOptions):
     first_trigger_character: str
-    more_trigger_character: Optional[List[str]] = None
+    more_trigger_character: Optional[List[str]]
 
 
 class DocumentOnTypeFormattingParams(TextDocumentPositionParams):

--- a/pygls/lsp/types/language_features/range_formatting.py
+++ b/pygls/lsp/types/language_features/range_formatting.py
@@ -32,7 +32,7 @@ from pygls.lsp.types.language_features.formatting import FormattingOptions
 
 
 class DocumentRangeFormattingClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class DocumentRangeFormattingOptions(WorkDoneProgressOptions):

--- a/pygls/lsp/types/language_features/references.py
+++ b/pygls/lsp/types/language_features/references.py
@@ -32,7 +32,7 @@ from pygls.lsp.types.basic_structures import (Model, PartialResultParams,
 
 
 class ReferenceClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class ReferenceOptions(WorkDoneProgressOptions):

--- a/pygls/lsp/types/language_features/rename.py
+++ b/pygls/lsp/types/language_features/rename.py
@@ -36,14 +36,14 @@ class PrepareSupportDefaultBehavior(enum.IntEnum):
 
 
 class RenameClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    prepare_support: Optional[bool] = False
-    prepare_support_default_behavior: Optional[PrepareSupportDefaultBehavior] = None
-    honors_change_annotations: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    prepare_support: Optional[bool]
+    prepare_support_default_behavior: Optional[PrepareSupportDefaultBehavior]
+    honors_change_annotations: Optional[bool]
 
 
 class RenameOptions(WorkDoneProgressOptions):
-    prepare_provider: Optional[bool] = False
+    prepare_provider: Optional[bool]
 
 
 class RenameParams(TextDocumentPositionParams, WorkDoneProgressParams):

--- a/pygls/lsp/types/language_features/selection_range.py
+++ b/pygls/lsp/types/language_features/selection_range.py
@@ -33,7 +33,7 @@ from pygls.lsp.types.basic_structures import (Model, PartialResultParams, Positi
 
 
 class SelectionRangeClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class SelectionRangeOptions(WorkDoneProgressOptions):
@@ -54,7 +54,7 @@ class SelectionRangeParams(WorkDoneProgressParams, PartialResultParams):
 
 class SelectionRange(Model):
     range: Range
-    parent: Optional['SelectionRange'] = None
+    parent: Optional['SelectionRange']
 
 
 SelectionRange.update_forward_refs()

--- a/pygls/lsp/types/language_features/semantic_tokens.py
+++ b/pygls/lsp/types/language_features/semantic_tokens.py
@@ -34,7 +34,7 @@ from pygls.lsp.types.basic_structures import (Model, PartialResultParams, Range,
 
 
 class SemanticTokensWorkspaceClientCapabilities(Model):
-    refresh_support: Optional[bool] = False
+    refresh_support: Optional[bool]
 
 
 class SemanticTokenTypes(str, enum.Enum):
@@ -85,12 +85,12 @@ class SemanticTokensLegend(Model):
 
 
 class SemanticTokensRequestsFull(Model):
-    delta: Optional[bool] = False
+    delta: Optional[bool]
 
 
 class SemanticTokensRequests(Model):
-    range: Optional[Union[bool, Dict]] = None
-    full: Optional[Union[bool, SemanticTokensRequestsFull]] = None
+    range: Optional[Union[bool, Dict]]
+    full: Optional[Union[bool, SemanticTokensRequestsFull]]
 
 
 class SemanticTokensClientCapabilities(Model):
@@ -98,15 +98,15 @@ class SemanticTokensClientCapabilities(Model):
     token_types: List[str]
     token_modifiers: List[str]
     formats: List[TokenFormat]
-    overlapping_token_support: Optional[bool] = False
-    multiline_token_support: Optional[bool] = False
-    dynamic_registration: Optional[bool] = False
+    overlapping_token_support: Optional[bool]
+    multiline_token_support: Optional[bool]
+    dynamic_registration: Optional[bool]
 
 
 class SemanticTokensOptions(WorkDoneProgressOptions):
     legend: SemanticTokensLegend
-    range: Optional[Union[bool, Dict]] = None
-    full: Optional[Union[bool, SemanticTokensRequestsFull]] = None
+    range: Optional[Union[bool, Dict]]
+    full: Optional[Union[bool, SemanticTokensRequestsFull]]
 
 
 class SemanticTokensRegistrationOptions(TextDocumentRegistrationOptions, SemanticTokensOptions, StaticRegistrationOptions):
@@ -119,7 +119,7 @@ class SemanticTokensParams(WorkDoneProgressParams, PartialResultParams):
 
 class SemanticTokens(Model):
     data: List[int]
-    result_id: Optional[str] = None
+    result_id: Optional[str]
 
 
 class SemanticTokensPartialResult(Model):
@@ -134,12 +134,12 @@ class SemanticTokensDeltaParams(WorkDoneProgressParams, PartialResultParams):
 class SemanticTokensEdit(Model):
     start: int
     delete_count: int
-    data: Optional[List[int]] = None
+    data: Optional[List[int]]
 
 
 class SemanticTokensDelta(Model):
     edits: List[SemanticTokensEdit]
-    result_id: Optional[str] = None
+    result_id: Optional[str]
 
 
 class SemanticTokensDeltaPartialResult(Model):

--- a/pygls/lsp/types/language_features/signature_help.py
+++ b/pygls/lsp/types/language_features/signature_help.py
@@ -33,24 +33,24 @@ from pygls.lsp.types.basic_structures import (MarkupContent, MarkupKind, Model, 
 
 
 class SignatureHelpInformationParameterInformationClientCapabilities(Model):
-    label_offset_support: Optional[bool] = False
+    label_offset_support: Optional[bool]
 
 
 class SignatureHelpInformationClientCapabilities(Model):
-    documentation_format: Optional[List[MarkupKind]] = None
-    parameter_information: Optional[SignatureHelpInformationParameterInformationClientCapabilities] = None
-    active_parameter_support: Optional[bool] = False
+    documentation_format: Optional[List[MarkupKind]]
+    parameter_information: Optional[SignatureHelpInformationParameterInformationClientCapabilities]
+    active_parameter_support: Optional[bool]
 
 
 class SignatureHelpClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    signature_information: Optional[SignatureHelpInformationClientCapabilities] = None
-    context_support: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    signature_information: Optional[SignatureHelpInformationClientCapabilities]
+    context_support: Optional[bool]
 
 
 class SignatureHelpOptions(WorkDoneProgressOptions):
-    trigger_characters: Optional[List[str]] = None
-    retrigger_characters: Optional[List[str]] = None
+    trigger_characters: Optional[List[str]]
+    retrigger_characters: Optional[List[str]]
 
 
 class SignatureHelpTriggerKind(enum.IntEnum):
@@ -61,28 +61,28 @@ class SignatureHelpTriggerKind(enum.IntEnum):
 
 class ParameterInformation(Model):
     label: Union[str, Tuple[int, int]]
-    documentation: Optional[Union[str, MarkupContent]] = None
+    documentation: Optional[Union[str, MarkupContent]]
 
 
 class SignatureInformation(Model):
     label: str
-    documentation: Optional[Union[str, MarkupContent]] = None
-    parameters: Optional[List[ParameterInformation]] = None
-    active_parameter: Optional[int] = None
+    documentation: Optional[Union[str, MarkupContent]]
+    parameters: Optional[List[ParameterInformation]]
+    active_parameter: Optional[int]
 
 
 class SignatureHelp(Model):
     signatures: List[SignatureInformation]
-    active_signature: Optional[NumType] = None
-    active_parameter: Optional[NumType] = None
+    active_signature: Optional[NumType]
+    active_parameter: Optional[NumType]
 
 
 class SignatureHelpContext(Model):
     trigger_kind: SignatureHelpTriggerKind
     is_retrigger: bool
-    trigger_character: Optional[str] = None
-    active_signature_help: Optional[SignatureHelp] = None
+    trigger_character: Optional[str]
+    active_signature_help: Optional[SignatureHelp]
 
 
 class SignatureHelpParams(TextDocumentPositionParams, WorkDoneProgressParams):
-    context: Optional[SignatureHelpContext] = None
+    context: Optional[SignatureHelpContext]

--- a/pygls/lsp/types/language_features/type_definition.py
+++ b/pygls/lsp/types/language_features/type_definition.py
@@ -33,8 +33,8 @@ from pygls.lsp.types.basic_structures import (Model, StaticRegistrationOptions,
 
 
 class TypeDefinitionClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    link_support: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    link_support: Optional[bool]
 
 
 class TypeDefinitionOptions(WorkDoneProgressOptions):

--- a/pygls/lsp/types/text_synchronization.py
+++ b/pygls/lsp/types/text_synchronization.py
@@ -38,9 +38,9 @@ class TextDocumentSyncKind(enum.IntEnum):
 
 
 class TextDocumentSyncOptions(Model):
-    open_close: Optional[bool] = False
-    change: Optional[TextDocumentSyncKind] = TextDocumentSyncKind.NONE
+    open_close: Optional[bool]
+    change: Optional[TextDocumentSyncKind]
 
 
 class TextDocumentSaveRegistrationOptions(TextDocumentRegistrationOptions):
-    include_text: Optional[bool] = False
+    include_text: Optional[bool]

--- a/pygls/lsp/types/window.py
+++ b/pygls/lsp/types/window.py
@@ -49,18 +49,18 @@ class MessageActionItem(Model):
 class ShowMessageRequestParams(Model):
     type: MessageType
     message: str
-    actions: Optional[List[MessageActionItem]] = None
+    actions: Optional[List[MessageActionItem]]
 
 
 class ShowDocumentClientCapabilities(Model):
-    support: Optional[bool] = False
+    support: Optional[bool]
 
 
 class ShowDocumentParams(Model):
     uri: URI
-    external: Optional[bool] = False
-    take_focus: Optional[bool] = False
-    selection: Optional[Range] = None
+    external: Optional[bool]
+    take_focus: Optional[bool]
+    selection: Optional[Range]
 
 
 class ShowDocumentResult(Model):
@@ -68,11 +68,11 @@ class ShowDocumentResult(Model):
 
 
 class ShowMessageRequestActionItem(Model):
-    additional_properties_support: Optional[bool] = False
+    additional_properties_support: Optional[bool]
 
 
 class ShowMessageRequestClientCapabilities(Model):
-    message_action_item: Optional[ShowMessageRequestActionItem] = None
+    message_action_item: Optional[ShowMessageRequestActionItem]
 
 
 class LogMessageParams(Model):

--- a/pygls/lsp/types/workspace.py
+++ b/pygls/lsp/types/workspace.py
@@ -158,7 +158,7 @@ class DidOpenTextDocumentParams(Model):
 class TextDocumentContentChangeEvent(Model):
     range: Optional[Range]
     range_length: Optional[NumType]
-    text: str = ''
+    text: str
 
 
 class TextDocumentContentChangeTextEvent(Model):
@@ -183,7 +183,7 @@ class WillSaveTextDocumentParams(Model):
 
 
 class SaveOptions(Model):
-    include_text: bool = False
+    include_text: Optional[bool]
 
 
 class DidSaveTextDocumentParams(Model):

--- a/pygls/lsp/types/workspace.py
+++ b/pygls/lsp/types/workspace.py
@@ -37,8 +37,8 @@ from pygls.lsp.types.language_features.document_symbol import (WorkspaceCapabili
 
 
 class WorkspaceFoldersServerCapabilities(Model):
-    supported: Optional[bool] = False
-    change_notifications: Optional[Union[bool, str]] = None
+    supported: Optional[bool]
+    change_notifications: Optional[Union[bool, str]]
 
 
 class WorkspaceFolder(Model):
@@ -56,7 +56,7 @@ class DidChangeWorkspaceFoldersParams(Model):
 
 
 class DidChangeConfigurationClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class DidChangeConfigurationParams(Model):
@@ -64,8 +64,8 @@ class DidChangeConfigurationParams(Model):
 
 
 class ConfigurationItem(Model):
-    scope_uri: Optional[str] = None
-    section: Optional[str] = None
+    scope_uri: Optional[str]
+    section: Optional[str]
 
 
 class ConfigurationParams(Model):
@@ -73,7 +73,7 @@ class ConfigurationParams(Model):
 
 
 class DidChangeWatchedFilesClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class WatchKind(enum.IntFlag):
@@ -84,7 +84,7 @@ class WatchKind(enum.IntFlag):
 
 class FileSystemWatcher(Model):
     glob_pattern: str
-    kind: Optional[WatchKind] = WatchKind.Create | WatchKind.Change | WatchKind.Delete
+    kind: Optional[WatchKind]
 
 
 class DidChangeWatchedFilesRegistrationOptions(Model):
@@ -107,9 +107,9 @@ class DidChangeWatchedFilesParams(Model):
 
 
 class WorkspaceSymbolClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    symbol_kind: Optional[WorkspaceCapabilitiesSymbolKind] = None
-    tag_support: Optional[WorkspaceCapabilitiesTagSupport] = None
+    dynamic_registration: Optional[bool]
+    symbol_kind: Optional[WorkspaceCapabilitiesSymbolKind]
+    tag_support: Optional[WorkspaceCapabilitiesTagSupport]
 
 
 class WorkspaceSymbolOptions(WorkDoneProgressOptions):
@@ -125,7 +125,7 @@ class WorkspaceSymbolParams(WorkDoneProgressParams, PartialResultParams):
 
 
 class ExecuteCommandClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
+    dynamic_registration: Optional[bool]
 
 
 class ExecuteCommandOptions(WorkDoneProgressOptions):
@@ -138,17 +138,17 @@ class ExecuteCommandRegistrationOptions(ExecuteCommandOptions):
 
 class ExecuteCommandParams(WorkDoneProgressParams):
     command: str
-    arguments: Optional[List[Any]] = None
+    arguments: Optional[List[Any]]
 
 
 class ApplyWorkspaceEditParams(Model):
     edit: WorkspaceEdit
-    label: Optional[str] = None
+    label: Optional[str]
 
 
 class ApplyWorkspaceEditResponse(Model):
     applied: bool
-    failure_reason: Optional[str] = None
+    failure_reason: Optional[str]
 
 
 class DidOpenTextDocumentParams(Model):
@@ -156,8 +156,8 @@ class DidOpenTextDocumentParams(Model):
 
 
 class TextDocumentContentChangeEvent(Model):
-    range: Optional[Range] = None
-    range_length: Optional[NumType] = None
+    range: Optional[Range]
+    range_length: Optional[NumType]
     text: str = ''
 
 
@@ -188,7 +188,7 @@ class SaveOptions(Model):
 
 class DidSaveTextDocumentParams(Model):
     text_document: TextDocumentIdentifier
-    text: Optional[str] = None
+    text: Optional[str]
 
 
 class DidCloseTextDocumentParams(Model):
@@ -196,7 +196,7 @@ class DidCloseTextDocumentParams(Model):
 
 
 class TextDocumentSyncClientCapabilities(Model):
-    dynamic_registration: Optional[bool] = False
-    will_save: Optional[bool] = False
-    will_save_wait_until: Optional[bool] = False
-    did_save: Optional[bool] = False
+    dynamic_registration: Optional[bool]
+    will_save: Optional[bool]
+    will_save_wait_until: Optional[bool]
+    did_save: Optional[bool]

--- a/tests/lsp/test_completion.py
+++ b/tests/lsp/test_completion.py
@@ -72,7 +72,7 @@ class TestCompletions(unittest.TestCase):
         assert response['items'][0]['label'] == 'test1'
         assert response['items'][0]['kind'] == CompletionItemKind.Method
         assert response['items'][0]['preselect'] == True
-        assert response['items'][0]['deprecated'] == False
+        assert 'deprecated' not in response['items'][0]
         assert 'tags' not in response['items'][0]
         assert 'detail' not in response['items'][0]
         assert 'documentation' not in response['items'][0]

--- a/tests/lsp/test_document_highlight.py
+++ b/tests/lsp/test_document_highlight.py
@@ -80,7 +80,7 @@ class TestDocumentHighlight(unittest.TestCase):
         assert response[0]['range']['start']['character'] == 0
         assert response[0]['range']['end']['line'] == 1
         assert response[0]['range']['end']['character'] == 1
-        assert response[0]['kind'] == DocumentHighlightKind.Text
+        assert 'kind' not in response[0]
 
         assert response[1]['range']['start']['line'] == 1
         assert response[1]['range']['start']['character'] == 1
@@ -102,4 +102,3 @@ class TestDocumentHighlight(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
## pygls is serializing too many fields

pygls 0.11.0 serializes certain optional fields, regardless of whether the server has explicitly set them - or whether the client has declared support for them.

Updating [jedi-language-server to take pygls 0.11.0](https://github.com/pappasam/jedi-language-server/pull/151) I see that we are now returning various fields that we previously didn't eg on `CompletionItem` we always set `deprecated` and `preselect`.  I'm pretty sure that this is wrong: not least, there are `deprecatedSupport` and `preselectSupport` on `CompletionClientCapabilities`: if the client has not declared support for these things then presumably we're not supposed to return them.

The approach I have taken is to remove all defaults for Optional fields:
- when the default was not `None`, this had the effect of making the field not optional after all, as above
- when the default was `None` it was redundant to declare it as such, so it's just more compact not to bother

This pull request partially undoes f248002a2fb8a10fb9a5d2bd5a0160a04a6189aa.  I'm not sure what the motivation for that was, but flagging it in case I've broken something.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md