### PR TITLE
replace references to localhost with 127.0.0.1 for docker and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Use `127.0.0.1` for tests and examples to avoid Docker issues ([#165])
+
 ## [0.11.1] - 06/21/2021
 
 ### Added
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+[#165]: https://github.com/openlawlibrary/pygls/issues/165
 [#198]: https://github.com/openlawlibrary/pygls/pull/198
 
 ## [0.11.0] - 06/18/2021

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@
 - [Samuel Roeca](https://github.com/pappasam)
 - [Tomoya Tanjo](https://github.com/tom-tan)
 - [yorodm](https://github.com/yorodm)
+- [bollwyvl](https://github.com/bollwyvl)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ def completions(params: CompletionParams):
         ]
     )
 
-server.start_tcp('localhost', 8080)
+server.start_tcp('127.0.0.1', 8080)
 ```
 
 Show completion list on the client:

--- a/docs/source/pages/advanced_usage.rst
+++ b/docs/source/pages/advanced_usage.rst
@@ -32,7 +32,7 @@ The code snippet below shows how to start the server in *TCP* mode.
 
     server = LanguageServer()
 
-    server.start_tcp('localhost', 8080)
+    server.start_tcp('127.0.0.1', 8080)
 
 STDIO
 ^^^^^

--- a/docs/source/pages/getting_started.rst
+++ b/docs/source/pages/getting_started.rst
@@ -45,10 +45,10 @@ code:
 
    server = LanguageServer()
 
-   server.start_tcp('localhost', 8080)
+   server.start_tcp('127.0.0.1', 8080)
 
 After running the code above, server will start listening for incoming
-``Json RPC`` requests on ``http://localhost:8080``.
+``Json RPC`` requests on ``http://127.0.0.1:8080``.
 
 Register Features and Commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_server_connection.py
+++ b/tests/test_server_connection.py
@@ -18,7 +18,7 @@ async def test_tcp_connection_lost():
     server.lsp.connection_lost = Mock()
 
     # Run the server over TCP in a separate thread
-    server_thread = Thread(target=server.start_tcp, args=('localhost', 0, ))
+    server_thread = Thread(target=server.start_tcp, args=('127.0.0.1', 0, ))
     server_thread.daemon = True
     server_thread.start()
 
@@ -28,7 +28,7 @@ async def test_tcp_connection_lost():
 
     # Simulate client's connection
     port = server._server.sockets[0].getsockname()[1]
-    reader, writer = await asyncio.open_connection('localhost', port)
+    reader, writer = await asyncio.open_connection('127.0.0.1', port)
     await asyncio.sleep(1)
 
     assert server.lsp.connection_made.called


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This replaces all references to `localhost` with `127.0.0.1`.

I've verified this locally this as a patch to the conda-forge feedstock, which builds under Docker: I'm not a huge Docker fan, but it is _a thing_, and it seemed like updating the docs along with the tests might save someone some trouble in the future.

### References

- fixes #165

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
