### PR TITLE
Add env to .gitignore

### DIFF
--- a/examples/json-extension/.gitignore
+++ b/examples/json-extension/.gitignore
@@ -3,3 +3,4 @@ node_modules
 client/server
 .vscode-test
 .vscode/settings.json
+env


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

The instructions on the `README` tell the user to create an environment called `env`. I guess we should match the `.gitignore`.

## Code review checklist (for code reviewer to complete)

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Commit messages are meaningful (see [this][commit messages] for details)
- [X] Tests have been included and/or updated, as appropriate
- [X] Docstrings have been included and/or updated, as appropriate
- [X] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
