### PR TITLE
Progress notifications does not contain the field `kind`

### DIFF
--- a/examples/json-extension/server/server.py
+++ b/examples/json-extension/server/server.py
@@ -202,16 +202,16 @@ async def progress(ls: JsonLanguageServer, *args):
     # Create
     await ls.progress.create_async(token)
     # Begin
-    ls.progress.begin(token, WorkDoneProgressBegin(title='Indexing', percentage=0))
+    ls.progress.begin(token, WorkDoneProgressBegin(kind='begin', title='Indexing', percentage=0))
     # Report
     for i in range(1, 10):
         ls.progress.report(
             token,
-            WorkDoneProgressReport(message=f'{i * 10}%', percentage= i * 10),
+            WorkDoneProgressReport(kind='progress', message=f'{i * 10}%', percentage= i * 10),
         )
         await asyncio.sleep(2)
     # End
-    ls.progress.end(token, WorkDoneProgressEnd(message='Finished'))
+    ls.progress.end(token, WorkDoneProgressEnd(kind='end', message='Finished'))
 
 
 @json_server.command(JsonLanguageServer.CMD_REGISTER_COMPLETIONS)


### PR DESCRIPTION
## `WorkDoneProgress*` fields `kind` are excluded when sending to client(editor)

- I think this originated from migration to pydantic
- `WorkDoneProgressBegin` has field `kind` with default value `'begin'` @ [code](https://github.com/openlawlibrary/pygls/blob/master/pygls/lsp/types/basic_structures.py#L443)
- this eventually generates notification @ [code](https://github.com/openlawlibrary/pygls/blob/bbf671f509b0d499a006daeeae8cdb78e3419fe5/pygls/protocol.py#L459)
- however the problem is [here](https://github.com/openlawlibrary/pygls/blob/bbf671f509b0d499a006daeeae8cdb78e3419fe5/pygls/protocol.py#L382) when model is serialized to `json`
```python
            body = data.json(by_alias=True, exclude_unset=True, encoder=default_serializer)
```
- `exclude_unset` causes the object to ignore `kind = 'begin'` since it was initialized with default value -- [docs](https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson)
- this is better illustrated in the logs section bellow

## Logs
Python code [here](https://github.com/openlawlibrary/pygls/blob/bbf671f509b0d499a006daeeae8cdb78e3419fe5/examples/json-extension/server/server.py#L205) in the example json-server:
```python
    ls.progress.begin(token, WorkDoneProgressBegin(title='Scan', percentage=0))
```
Generates the following. Notice how `WorkDoneProgressBegin` contains `kind='begin'` (line 1), however the data send does not contain this field (`params->value->kind?`) (line 2).
```
Sending notification: "$/progress" token='token' value=WorkDoneProgressBegin(kind='begin', title='Scan', cancellable=None, message=None, percentage=0)
Sending data: {"jsonrpc": "2.0", "method": "$/progress", "params": {"token": "token", "value": {"title": "Scan", "percentage": 0}}}
```

## Solution?
- all of the `WorkDoneProgress*` messages are affected by this issue
- workaround is to pass `kind` explicitly, like this PR shows
- I am not sure why we are excluding unset fields.. maybe the solution is to remove `exclude_unset` option, however this might cause more problems (I am sure there was a reason to put this option there in the first place)
- What do you think? (this PR does not have to be merged, it can be viewed as a demonstration of the problem)

## Repro

1) Open json example server
2) Start progress command
3) Observe that there is no task running at the bottom of the window (with name "indexing")

After this PR:
1) Open json example server
2) Start progress command
3) Indexing task is shown

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
