### PR TITLE
change pythonPath settings for VSC

### DIFF
--- a/examples/json-extension/README.md
+++ b/examples/json-extension/README.md
@@ -4,7 +4,7 @@
 
 1. `python -m venv env`
 1. `python -m pip install -e .` from root directory
-1. Create `.vscode/settings.json` file and set `python.pythonPath` to point to your python environment where `pygls` is installed
+1. Create `.vscode/settings.json` file and set `python.interpreterPath` to point to your python environment where `pygls` is installed
 
 ## Install Client Dependencies
 


### PR DESCRIPTION
## Description
when it comes to setting correct Python path for lanuching a vsc, it should be python.interpreterPath instead of python.pythonPath

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
