### PR TITLE
json-extension: use an unique token for progress example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 ### Fixed
 
+ - Fix progress example in json extension. ([#230]) 
+
+[#230]: https://github.com/openlawlibrary/pygls/issues/230
+
 ## [1.0.0] - 2/12/2022
 ### Changed
 BREAKING CHANGE: Replaced `pydantic` with [`lsprotocol`](https://github.com/microsoft/lsprotocol)

--- a/examples/json-extension/server/server.py
+++ b/examples/json-extension/server/server.py
@@ -197,7 +197,7 @@ def semantic_tokens(ls: JsonLanguageServer, params: SemanticTokensParams):
 @json_server.command(JsonLanguageServer.CMD_PROGRESS)
 async def progress(ls: JsonLanguageServer, *args):
     """Create and start the progress on the client."""
-    token = 'token'
+    token = str(uuid.uuid4())
     # Create
     await ls.progress.create_async(token)
     # Begin


### PR DESCRIPTION
The spec [1] and pygls implementation [2] need the token to be unique.

By using an hardcoded token like this, the progress works only one time,
the second time there's an error that token is already registered.

[1]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#serverInitiatedProgress

[2]: https://github.com/openlawlibrary/pygls//blob/ee17487e4f40f971e7ec6f7711fa8334c5b7b127/pygls/progress.py#L28

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
