### PR TITLE
API: drop None rather than unset in JSON response

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
 - [Matej Kašťák](https://github.com/MatejKastak)
 - [Max O'Cull](https://github.com/Maxattax97)
 - [Samuel Roeca](https://github.com/pappasam)
+- [Tom BH](https://github.com/tombh)
 - [Tomoya Tanjo](https://github.com/tom-tan)
 - [yorodm](https://github.com/yorodm)
 - [bollwyvl](https://github.com/bollwyvl)

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -379,7 +379,7 @@ class JsonRPCProtocol(asyncio.Protocol):
             return
 
         try:
-            body = data.json(by_alias=True, exclude_unset=True, encoder=default_serializer)
+            body = data.json(by_alias=True, exclude_none=True, encoder=default_serializer)
             logger.info('Sending data: %s', body)
 
             body = body.encode(self.CHARSET)

--- a/tests/lsp/test_progress.py
+++ b/tests/lsp/test_progress.py
@@ -1,0 +1,114 @@
+############################################################################
+# Copyright(c) Open Law Library. All rights reserved.                      #
+# See ThirdPartyNotices.txt in the project root for additional notices.    #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License")           #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http: // www.apache.org/licenses/LICENSE-2.0                         #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" BASIS,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+import unittest
+from typing import List, Optional
+
+import time
+from pygls.lsp.methods import (
+    CODE_LENS,
+    PROGRESS_NOTIFICATION
+
+)
+from pygls.lsp.types import (
+    CodeLens,
+    CodeLensParams,
+    CodeLensOptions,
+    TextDocumentIdentifier,
+    WorkDoneProgressBegin,
+    WorkDoneProgressEnd,
+    WorkDoneProgressReport
+)
+from pygls.lsp.types.basic_structures import ProgressParams
+from ..conftest import CALL_TIMEOUT, ClientServer
+
+
+PROGRESS_TOKEN = 'token'
+
+
+class TestCodeLens(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.client_server = ClientServer()
+        cls.client, cls.server = cls.client_server
+        cls.notifications: List[ProgressParams] = []
+
+        @cls.server.feature(
+            CODE_LENS,
+            CodeLensOptions(
+                resolve_provider=False,
+                work_done_progress=PROGRESS_TOKEN
+            ),
+        )
+        def f1(params: CodeLensParams) -> Optional[List[CodeLens]]:
+            cls.server.lsp.progress.begin(
+                PROGRESS_TOKEN,
+                WorkDoneProgressBegin(title='starting', percentage=0)
+            )
+            cls.server.lsp.progress.report(
+                PROGRESS_TOKEN,
+                WorkDoneProgressReport(message='doing', percentage=50),
+            )
+            cls.server.lsp.progress.end(
+                PROGRESS_TOKEN,
+                WorkDoneProgressEnd(message='done')
+            )
+            return None
+
+        @cls.client.feature(
+            PROGRESS_NOTIFICATION
+        )
+        def f2(params):
+            cls.notifications.append(params)
+
+        cls.client_server.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client_server.stop()
+
+    def test_capabilities(self):
+        capabilities = self.server.server_capabilities
+
+        assert capabilities.code_lens_provider
+        assert capabilities.code_lens_provider.work_done_progress == PROGRESS_TOKEN
+
+    def test_progress_notifications(self):
+        self.client.lsp.send_request(
+            CODE_LENS,
+            CodeLensParams(
+                text_document=TextDocumentIdentifier(uri='file://return.none'),
+                work_done_token=PROGRESS_TOKEN
+            ),
+        ).result(timeout=CALL_TIMEOUT)
+
+        time.sleep(0.1)
+
+        assert len(self.notifications) == 3
+        assert self.notifications[0].token == PROGRESS_TOKEN
+        assert self.notifications[0].value == {
+            'kind': 'begin', 'title': 'starting', 'percentage': 0
+        }
+        assert self.notifications[1].value == {
+            'kind': 'report', 'message': 'doing', 'percentage': 50
+        }
+        assert self.notifications[2].value == {
+            'kind': 'end', 'message': 'done'
+        }
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/lsp/test_references.py
+++ b/tests/lsp/test_references.py
@@ -97,4 +97,3 @@ class TestReferences(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
This addresses #217 and #231.

I am still new to the project, so I may not have the full story. But it
started with a somewhat far-reaching merge to remove defaults from all
serialisable fields in the API: #198. This had the knock-on effect of
regressing progress notifications, as reported by @MatejKastak in #217.
One of their suggestions is to not use `exclude_unset=True`. Some months
later @dimbleby suggested that `exclude_none=True` would also fix the
issue[1]. Considering those 2 suggestions, let's replace
`exclude_unset=True` with `exclude_none=True`.

1. https://github.com/openlawlibrary/pygls/pull/198#issuecomment-1086864429

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
