### PR TITLE
Fix Outdated Documentation and Docstrings

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 - [DeathAxe](https://github.com/deathaxe)
 - [Denis Loginov](https://github.com/dinvlad)
 - [Jérome Perrin](https://github.com/perrinjerome)
+- [Laurence Warne](https://github.com/LaurenceWarne)
 - [Matej Kašťák](https://github.com/MatejKastak)
 - [Max O'Cull](https://github.com/Maxattax97)
 - [Samuel Roeca](https://github.com/pappasam)

--- a/docs/source/pages/getting_started.rst
+++ b/docs/source/pages/getting_started.rst
@@ -58,7 +58,7 @@ Register Features and Commands
 
 .. code:: python
 
-    @server.feature(COMPLETION, trigger_characters=[','])
+    @server.feature(COMPLETION, CompletionOptions(trigger_characters=[',']))
     def completions(params: CompletionParams):
         """Returns completion items."""
         return CompletionList(

--- a/pygls/feature_manager.py
+++ b/pygls/feature_manager.py
@@ -147,7 +147,7 @@ class FeatureManager:
         """Decorator used to register LSP features.
 
         Example:
-            @ls.feature('textDocument/completion', triggerCharacters=['.'])
+            @ls.feature('textDocument/completion', CompletionItems(trigger_characters=['.']))
         """
         def decorator(f):
             # Validate

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -328,9 +328,9 @@ class LanguageServer(Server):
         """Decorator used to register LSP features.
 
         Example:
-            @ls.feature('textDocument/completion', triggerCharacters=['.'])
-            def completions(ls, params: CompletionRequest):
-                return CompletionList(False, [CompletionItem("Completion 1")])
+            @ls.feature('textDocument/completion', CompletionOptions(trigger_characters=['.']))
+            def completions(ls, params: CompletionParams):
+                return CompletionList(is_incomplete=False, items=[CompletionItem("Completion 1")])
         """
         return self.lsp.fm.feature(feature_name, options)
 


### PR DESCRIPTION
## Description

First of all thanks, I've found this package really useful.  This small PR just fixes a few bits of (I think) outdated documentation in `getting_started` and in a few docstrings.

Possibly related is https://github.com/openlawlibrary/pygls/pull/94, though I'm a bit confused by that PR since the diff appears to be the opposite of what the PR title says?

Thanks :slightly_smiling_face:  

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
