### PR TITLE
Deprecations

### DIFF
--- a/pygls/server.py
+++ b/pygls/server.py
@@ -165,7 +165,7 @@ class Server:
         elif not IS_PYODIDE:
             asyncio.set_event_loop(asyncio.SelectorEventLoop())
 
-        self.loop = loop or asyncio.get_event_loop()
+        self.loop = loop or asyncio.new_event_loop()
 
         try:
             if not IS_PYODIDE:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,6 @@ requires = ["setuptools>=44", "wheel", "setuptools_scm>=3.4.3", "toml"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
Fixing a couple of deprecation warnings

```
  /home/dch/pygls/pygls/server.py:168: DeprecationWarning: There is no current event loop
    self.loop = loop or asyncio.get_event_loop()
```
and
```
  /home/dch/.virtualenvs/pygls/lib/python3.10/site-packages/pytest_asyncio/plugin.py:191: DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)
```