### PR TITLE
Keep track of a text document's `language_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- `Document` objects now expose a text document's `language_id`
+
 ## [0.12] - 04/07/2022
 
 ### Added

--- a/pygls/workspace.py
+++ b/pygls/workspace.py
@@ -20,7 +20,7 @@ import io
 import logging
 import os
 import re
-from typing import List, Pattern
+from typing import List, Optional, Pattern
 
 from pygls.lsp.types import (NumType, Position, Range, TextDocumentContentChangeEvent,
                              TextDocumentItem, TextDocumentSyncKind,
@@ -160,11 +160,19 @@ def range_to_utf16(lines: List[str], range: Range) -> Range:
 
 class Document(object):
 
-    def __init__(self, uri, source=None, version=None, local=True,
-                 sync_kind=TextDocumentSyncKind.INCREMENTAL):
+    def __init__(
+        self,
+        uri: str,
+        source: Optional[str] = None,
+        version: Optional[NumType] = None,
+        language_id: Optional[str] = None,
+        local: bool = True,
+        sync_kind: TextDocumentSyncKind = TextDocumentSyncKind.INCREMENTAL
+    ):
         self.uri = uri
         self.version = version
         self.path = to_fs_path(uri)
+        self.language_id = language_id
         self.filename = os.path.basename(self.path)
 
         self._local = local
@@ -333,12 +341,20 @@ class Workspace(object):
             for folder in workspace_folders:
                 self.add_folder(folder)
 
-    def _create_document(self,
-                         doc_uri: str,
-                         source: str = None,
-                         version: NumType = None) -> Document:
-        return Document(doc_uri, source=source, version=version,
-                        sync_kind=self._sync_kind)
+    def _create_document(
+        self,
+        doc_uri: str,
+        source: Optional[str] = None,
+        version: Optional[NumType] = None,
+        language_id: Optional[str] = None,
+    ) -> Document:
+        return Document(
+            doc_uri,
+            source=source,
+            version=version,
+            language_id=language_id,
+            sync_kind=self._sync_kind
+        )
 
     def add_folder(self, folder: WorkspaceFolder):
         self._folders[folder.uri] = folder
@@ -372,7 +388,8 @@ class Workspace(object):
         self._docs[doc_uri] = self._create_document(
             doc_uri,
             source=text_document.text,
-            version=text_document.version
+            version=text_document.version,
+            language_id=text_document.language_id,
         )
 
     def remove_document(self, doc_uri: str):

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -84,6 +84,12 @@ def test_bf_text_document_did_open(client_server):
 
     assert len(server.lsp.workspace.documents) == 1
 
+    document = server.workspace.get_document(__file__)
+    assert document.uri == __file__
+    assert document.version == 1
+    assert document.source == "test"
+    assert document.language_id == "python"
+
 
 @pytest.mark.skipif(IS_PYODIDE, reason='threads are not available in pyodide.')
 def test_command_async(client_server):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This ensures that `pygls` remembers the `language_id` of text documents opened by the client.

Closes #212 

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [/] Standalone docs have been updated accordingly
- [/] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
