### PR TITLE
pyodide_testrunner: display console on error

### DIFF
--- a/pyodide_testrunner/run.py
+++ b/pyodide_testrunner/run.py
@@ -12,6 +12,7 @@ from multiprocessing import Process, Queue
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.support import expected_conditions as EC
 
 
@@ -88,13 +89,15 @@ def main():
         driver.get(f'http://localhost:{port}?whl={whl}')
 
         wait = WebDriverWait(driver, 120)
-        button = wait.until(EC.element_to_be_clickable((By.ID, 'exit-code')))
+        try:
+            button = wait.until(EC.element_to_be_clickable((By.ID, 'exit-code')))
+            exit_code = int(button.text)
+        except WebDriverException as e:
+            print(f'Error while running test: {e!r}')
+            exit_code = 1
 
         console = driver.find_element(By.ID, 'console')
         print(console.text)
-
-        exit_code = int(button.text)
-
     finally:
         if hasattr(server_process, "kill"):
             server_process.kill()


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

If something is wrong with the test running on CI and selenium get a timeout,
the test output was not displayed.


## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [/] Docstrings have been included and/or updated, as appropriate
- [/] Standalone docs have been updated accordingly
- [/] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [/] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
