### PR TITLE
Fix websocket based servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning][semver].
   Overrideable in `LanguageServer.report_server_error()`: https://github.com/openlawlibrary/pygls/pull/282
 ### Fixed
 - `_data_recevied()` JSONRPC message parsing errors now caught
+- Fix "Task attached to a different loop" error in `Server.start_ws` ([#268])
 
 ## [0.12.4] - 24/10/2022
 ### Fixed

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -282,7 +282,7 @@ class Server:
                     json.loads(message, object_hook=deserialize_message)
                 )
 
-        start_server = websockets.serve(connection_made, host, port)
+        start_server = websockets.serve(connection_made, host, port, loop=self.loop)
         self._server = start_server.ws_server
         self.loop.run_until_complete(start_server)
 


### PR DESCRIPTION
This is an attempt at fixing #268

First this commit introduces a test that runs a websocket server in a separate thread.
**Note:** While the test appears to work as intended, due to running the server in a separate thread I'm unable to reproduce the exact error I see in the original issue. I instead get a different error about there not being an event loop.

```
$ pytest tests/test_server_connection.py::test_ws_server
=============================================== test session starts ================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /var/home/alex/Projects/pygls, configfile: pyproject.toml
plugins: typeguard-2.13.3, timeout-2.1.0, cov-3.0.0, asyncio-0.19.0, lsp-0.1.2
asyncio: mode=auto
collected 1 item                                                                                                   

tests/test_server_connection.py ^C

================================================= warnings summary =================================================
tests/test_server_connection.py::test_ws_server
  /var/home/alex/Projects/esbonio/.env/lib64/python3.10/site-packages/websockets/legacy/server.py:1006: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop()

tests/test_server_connection.py::test_ws_server
  /var/home/alex/Projects/esbonio/.env/lib64/python3.10/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-3 (start_ws)
  
  Traceback (most recent call last):
    File "/usr/lib64/python3.10/threading.py", line 1016, in _bootstrap_inner
      self.run()
    File "/usr/lib64/python3.10/threading.py", line 953, in run
      self._target(*self._args, **self._kwargs)
    File "/var/home/alex/Projects/pygls/pygls/server.py", line 308, in start_ws
      start_server = websockets.serve(connection_made, host, port)
    File "/var/home/alex/Projects/esbonio/.env/lib64/python3.10/site-packages/websockets/legacy/server.py", line 1006, in __init__
      loop = asyncio.get_event_loop()
    File "/usr/lib64/python3.10/asyncio/events.py", line 656, in get_event_loop
      raise RuntimeError('There is no current event loop in thread %r.'
  RuntimeError: There is no current event loop in thread 'Thread-3 (start_ws)'.
  
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/usr/lib64/python3.10/selectors.py:469: KeyboardInterrupt
(to show a full traceback on KeyboardInterrupt use --full-trace)
=============================================== 2 warnings in 4.15s ================================================
Task was destroyed but it is pending!
task: <Task pending name='Task-3' coro=<test_ws_server() done, defined at /var/home/alex/Projects/pygls/tests/test_server_connection.py:78> wait_for=<Future pending cb=[Task.task_wakeup()]>>

```

Next, the fix appears to work as I'm able to use websocket based servers with it, but it appears to rely on deprecated features.
```
================================================= warnings summary =================================================
tests/test_server_connection.py::test_ws_server
  /var/home/alex/Projects/esbonio/.env/lib64/python3.10/site-packages/websockets/legacy/server.py:1009: DeprecationWarning: remove loop argument
    warnings.warn("remove loop argument", DeprecationWarning)

tests/test_server_connection.py::test_ws_server
  /var/home/alex/Projects/esbonio/.env/lib64/python3.10/site-packages/websockets/legacy/protocol.py:203: DeprecationWarning: remove loop argument
    warnings.warn("remove loop argument", DeprecationWarning)

tests/test_server_connection.py::test_ws_server
  /var/home/alex/Projects/pygls/pygls/server.py:148: RuntimeWarning: coroutine 'WebSocketCommonProtocol.close' was never awaited
    self._ws.close()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================== 1 passed, 3 warnings in 0.60s ===========================================
```

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
