### PR TITLE
fix: Require Pydantic 1.10.2 when Python is 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 ### Fixed
 
+## [0.12.3] - 24/10/2022
+### Fixed
+- Require Pydantic 1.10.2 when Python is 3.11
+
 ## [0.12.2] - 26/09/2022
 ### Fixed
 - Relaxed the Python version upper bound to `<4`

--- a/pygls/__init__.py
+++ b/pygls/__init__.py
@@ -19,7 +19,7 @@
 import os
 import sys
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 
 IS_WIN = os.name == 'nt'
 IS_PYODIDE = 'pyodide' in sys.modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 setup_requires =
@@ -28,11 +29,12 @@ setup_requires =
     wheel
     setuptools_scm>=3.4.3
     toml
-python_requires = >=3.7,<4
+python_requires = >=3.7,<3.12
 packages = find:
 zip_safe = False
 install_requires =
-    pydantic>=1.9.1,<1.10
+    pydantic>=1.9.1,<1.10  ; python_version<"3.11"
+    pydantic>=1.10.2 ; python_version>="3.11"
     typeguard>=2.10.0,<3
 include_package_data = True
 tests_require =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{36,37,38,39,310,311}
 
 [testenv]
 extras =


### PR DESCRIPTION
This finally gives us Python 3.11 support.

See #234 for more discussion.

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
~~- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate~~
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])