### PR TITLE
Remove upper bound on pydantic for python <3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 ### Fixed
 
+## [0.12.4] - 24/10/2022
+### Fixed
+- Remove upper bound on Pydantic when Python is <3.11
+
 ## [0.12.3] - 24/10/2022
 ### Fixed
 - Require Pydantic 1.10.2 when Python is 3.11

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 - [DeathAxe](https://github.com/deathaxe)
 - [Denis Loginov](https://github.com/dinvlad)
 - [Jérome Perrin](https://github.com/perrinjerome)
+- [Karthik Nadig](https://github.com/karthiknadig)
 - [Laurence Warne](https://github.com/LaurenceWarne)
 - [Matej Kašťák](https://github.com/MatejKastak)
 - [Max O'Cull](https://github.com/Maxattax97)

--- a/pygls/__init__.py
+++ b/pygls/__init__.py
@@ -19,7 +19,7 @@
 import os
 import sys
 
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 
 IS_WIN = os.name == 'nt'
 IS_PYODIDE = 'pyodide' in sys.modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ python_requires = >=3.7,<3.12
 packages = find:
 zip_safe = False
 install_requires =
-    pydantic>=1.9.1,<1.10  ; python_version<"3.11"
+    pydantic>=1.9.1 ; python_version<"3.11"
     pydantic>=1.10.2 ; python_version>="3.11"
     typeguard>=2.10.0,<3
 include_package_data = True


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Currently the restriction on pydantic does not allow us select a single version that works for python 3.7-3.11. This PR removes the upper bound on python version <3.11. This allows pygls to select a single version of pydantic that works on all python versions.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
