### PR TITLE
fix: Improved error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning][semver].
 [#274]: https://github.com/openlawlibrary/pygls/issues/274
 
 ### Changed
+- Default behaviour change: uncaught errors are now sent as `showMessage` errors to client.
+  Overrideable in `LanguageServer.report_server_error()`: https://github.com/openlawlibrary/pygls/pull/282
 ### Fixed
+- `_data_recevied()` JSONRPC message parsing errors now caught
 
 ## [0.12.4] - 24/10/2022
 ### Fixed

--- a/docs/source/pages/advanced_usage.rst
+++ b/docs/source/pages/advanced_usage.rst
@@ -447,6 +447,19 @@ And method invocation example:
 
     server.send_notification('myCustomNotification', 'test data')
 
+Custom Error Reporting
+^^^^^^^^^^^^^^^^^^^^^^
+
+By default Pygls notifies the client to display any occurences of uncaught exceptions in the
+server. To override this behaviour define your own `report_server_error()` method like so:
+
+.. code:: python
+
+    Class CustomLanguageServer(LanguageServer):
+        def report_server_error(self, error: Exception, source: Union[PyglsError, JsonRpcException]):
+            pass
+
+
 Workspace
 ~~~~~~~~~
 

--- a/pygls/exceptions.py
+++ b/pygls/exceptions.py
@@ -188,6 +188,14 @@ class FeatureAlreadyRegisteredError(PyglsError):
         return f'Feature "{self.feature_name}" is already registered.'
 
 
+class FeatureRequestError(PyglsError):
+    pass
+
+
+class FeatureNotificationError(PyglsError):
+    pass
+
+
 class MethodTypeNotRegisteredError(PyglsError):
 
     def __init__(self, name):

--- a/tests/ls_setup.py
+++ b/tests/ls_setup.py
@@ -69,10 +69,10 @@ class PyodideClientServer:
     """Implementation of the `client_server` fixture for use in a pyodide
     environment."""
 
-    def __init__(self):
+    def __init__(self, LS=LanguageServer):
 
-        self.server = LanguageServer('pygls-server', 'v1')
-        self.client = LanguageServer('pygls-client', 'v1')
+        self.server = LS('pygls-server', 'v1')
+        self.client = LS('pygls-client', 'v1')
 
         self.server.lsp.connection_made(PyodideTestTransportAdapter(self.client))
         self.server.lsp._send_only_body = True
@@ -112,14 +112,14 @@ class PyodideClientServer:
 
 
 class NativeClientServer:
-    def __init__(self):
+    def __init__(self, LS=LanguageServer):
         # Client to Server pipe
         csr, csw = os.pipe()
         # Server to client pipe
         scr, scw = os.pipe()
 
         # Setup Server
-        self.server = LanguageServer('server', 'v1')
+        self.server = LS('server', 'v1')
         self.server_thread = threading.Thread(
             target=self.server.start_io,
             args=(os.fdopen(csr, "rb"), os.fdopen(scw, "wb")),
@@ -127,7 +127,7 @@ class NativeClientServer:
         self.server_thread.daemon = True
 
         # Setup client
-        self.client = LanguageServer('client', 'v1', asyncio.new_event_loop())
+        self.client = LS('client', 'v1', asyncio.new_event_loop())
         self.client_thread = threading.Thread(
             target=self.client.start_io,
             args=(os.fdopen(scr, "rb"), os.fdopen(csw, "wb")),

--- a/tests/lsp/test_errors.py
+++ b/tests/lsp/test_errors.py
@@ -1,0 +1,136 @@
+############################################################################
+# Copyright(c) Open Law Library. All rights reserved.                      #
+# See ThirdPartyNotices.txt in the project root for additional notices.    #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License")           #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#     http: // www.apache.org/licenses/LICENSE-2.0                         #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" BASIS,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+############################################################################
+
+from typing import Any, List, Union
+import time
+
+import pytest
+
+from pygls.exceptions import JsonRpcInternalError, PyglsError, JsonRpcException
+from pygls.lsp.methods import WINDOW_SHOW_MESSAGE
+from pygls.server import LanguageServer
+from pygls.lsp.types import MessageType
+
+from ..conftest import ClientServer
+
+ERROR_TRIGGER = "test/triggerError"
+ERROR_MESSAGE = "Testing errors"
+
+
+class CustomLanguageServerSafe(LanguageServer):
+    def report_server_error(
+        self, error: Exception, source: Union[PyglsError, JsonRpcException]
+    ):
+        pass
+
+
+class CustomLanguageServerPotentialRecursion(LanguageServer):
+    def report_server_error(
+        self, error: Exception, source: Union[PyglsError, JsonRpcException]
+    ):
+        raise Exception()
+
+
+class CustomLanguageServerSendAll(LanguageServer):
+    def report_server_error(
+        self, error: Exception, source: Union[PyglsError, JsonRpcException]
+    ):
+        self.show_message(self.default_error_message, msg_type=MessageType.Error)
+
+
+class ConfiguredLS(ClientServer):
+    def __init__(self, LS=LanguageServer):
+        super().__init__(LS)
+        self.init()
+
+    def init(self):
+        self.client.messages: List[str] = []
+
+        @self.server.feature(ERROR_TRIGGER)
+        def f1(params: Any):
+            raise Exception(ERROR_MESSAGE)
+
+        @self.client.feature(WINDOW_SHOW_MESSAGE)
+        def f2(params: Any):
+            self.client.messages.append(params.message)
+
+
+class CustomConfiguredLSSafe(ConfiguredLS):
+    def __init__(self):
+        super().__init__(CustomLanguageServerSafe)
+
+
+class CustomConfiguredLSPotentialRecusrion(ConfiguredLS):
+    def __init__(self):
+        super().__init__(CustomLanguageServerPotentialRecursion)
+
+
+class CustomConfiguredLSSendAll(ConfiguredLS):
+    def __init__(self):
+        super().__init__(CustomLanguageServerSendAll)
+
+
+@ConfiguredLS.decorate()
+def test_request_error_reporting_default(client_server):
+    client, _ = client_server
+    assert len(client.messages) == 0
+
+    with pytest.raises(JsonRpcInternalError, match=ERROR_MESSAGE):
+        client.lsp.send_request(ERROR_TRIGGER).result()
+
+    time.sleep(0.1)
+    assert len(client.messages) == 0
+
+
+@CustomConfiguredLSSendAll.decorate()
+def test_request_error_reporting_override(client_server):
+    client, _ = client_server
+    assert len(client.messages) == 0
+
+    with pytest.raises(JsonRpcInternalError, match=ERROR_MESSAGE):
+        client.lsp.send_request(ERROR_TRIGGER).result()
+
+    time.sleep(0.1)
+    assert len(client.messages) == 1
+
+
+@ConfiguredLS.decorate()
+def test_notification_error_reporting(client_server):
+    client, _ = client_server
+    client.lsp.notify(ERROR_TRIGGER)
+    time.sleep(0.1)
+
+    assert len(client.messages) == 1
+    assert client.messages[0] == LanguageServer.default_error_message
+
+
+@CustomConfiguredLSSafe.decorate()
+def test_overriding_error_reporting(client_server):
+    client, _ = client_server
+    client.lsp.notify(ERROR_TRIGGER)
+    time.sleep(0.1)
+
+    assert len(client.messages) == 0
+
+
+@CustomConfiguredLSPotentialRecusrion.decorate()
+def test_overriding_error_reporting_with_potential_recursion(client_server):
+    client, _ = client_server
+    client.lsp.notify(ERROR_TRIGGER)
+    time.sleep(0.1)
+
+    assert len(client.messages) == 0


### PR DESCRIPTION
This includes a notable, perhaps even controversial, behaviour change:
All errors other than LSP requests are now sent to the client as `showMessage.type = MessageType.Error` messages. This may result in existing custom LSP servers showing errors that were not seen before, these aren't new errors, just previously undisplayed errors.

Another advantage to this is that it is now easier to test error handling. When running end to end tests, all errors are now accessible in the client.

Also, `JsonRPCProtocol.data_receieved()` now catches unhandled errors.


Fixes #277.

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
