### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 ### Added
+### Changed
+### Fixed
 
+## [0.13.0] - 2/11/2022
+### Added
 - Add `name` and `version` arguments to the constructor of `LanguageServer` ([#274])
-
 [#274]: https://github.com/openlawlibrary/pygls/issues/274
-
 ### Changed
 - Default behaviour change: uncaught errors are now sent as `showMessage` errors to client.
   Overrideable in `LanguageServer.report_server_error()`: https://github.com/openlawlibrary/pygls/pull/282

--- a/pygls/__init__.py
+++ b/pygls/__init__.py
@@ -19,7 +19,7 @@
 import os
 import sys
 
-__version__ = "0.12.4"
+__version__ = "0.13.0"
 
 IS_WIN = os.name == 'nt'
 IS_PYODIDE = 'pyodide' in sys.modules


### PR DESCRIPTION
A minor version bump here, because there are 2 behaviour changes, namely more error messages being sent to the client, and a warning log line if `LanguageServer("my-server-name", "0.0.1")` is instantiated without the server name and version.

Added:
- Add `name` and `version` arguments to the constructor of `LanguageServer` ([#274]) [#274]: https://github.com/openlawlibrary/pygls/issues/274 Changed:
- Default behaviour change: uncaught errors are now sent as `showMessage` errors to client. Overrideable in `LanguageServer.report_server_error()`: https://github.com/openlawlibrary/pygls/pull/282 Fixed:
- `_data_recevied()` JSONRPC message parsing errors now caught
- Fix "Task attached to a different loop" error in `Server.start_ws` ([#268])
