### PR TITLE
Fixes for the v1.0 branch

### DIFF
--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -175,6 +175,7 @@ def default_converter():
 
     return converter
 
+
 class JsonRPCProtocol(asyncio.Protocol):
     """Json RPC protocol implementation using on top of `asyncio.Protocol`.
 
@@ -196,8 +197,10 @@ class JsonRPCProtocol(asyncio.Protocol):
 
     VERSION = '2.0'
 
-    def __init__(self, server):
+    def __init__(self, server, converter):
         self._server = server
+        self._converter = converter
+
         self._shutdown = False
 
         # Book keeping for in-flight requests
@@ -209,7 +212,6 @@ class JsonRPCProtocol(asyncio.Protocol):
         self._message_buf = []
 
         self._send_only_body = False
-        self._converter = default_converter()
 
     def __call__(self):
         return self
@@ -556,7 +558,7 @@ class JsonRPCProtocol(asyncio.Protocol):
             params=params,
             jsonrpc=JsonRPCProtocol.VERSION
         )
-        # breakpoint()
+
         self._send_data(notification)
 
     def send_request(self, method, params=None, callback=None, msg_id=None):
@@ -652,8 +654,8 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         workspace(Workspace): In memory workspace
     """
 
-    def __init__(self, server):
-        super().__init__(server)
+    def __init__(self, server, converter):
+        super().__init__(server, converter)
 
         self.workspace = None
         self.trace = None

--- a/pygls/workspace.py
+++ b/pygls/workspace.py
@@ -24,6 +24,7 @@ from typing import List, Optional, Pattern
 
 from lsprotocol.types import (
     Position, Range, TextDocumentContentChangeEvent,
+    TextDocumentContentChangeEvent_Type1,
     TextDocumentItem, TextDocumentSyncKind,
     VersionedTextDocumentIdentifier, WorkspaceFolder
 )
@@ -187,7 +188,7 @@ class Document(object):
     def __str__(self):
         return str(self.uri)
 
-    def _apply_incremental_change(self, change: TextDocumentContentChangeEvent) -> None:
+    def _apply_incremental_change(self, change: TextDocumentContentChangeEvent_Type1) -> None:
         """Apply an ``Incremental`` text change to the document"""
         lines = self.lines
         text = change.text
@@ -251,10 +252,8 @@ class Document(object):
             attributes "range" and "rangeLength" will be missing from ``Full``
             content update client requests in the pygls Python library.
 
-        NOTE: After adding pydantic models, "range" and "rangeLength" fileds
-        will be None if not passed by the client
         """
-        if change.range is not None:
+        if isinstance(change, TextDocumentContentChangeEvent_Type1):
             if self._is_sync_kind_incremental:
                 self._apply_incremental_change(change)
                 return

--- a/tests/lsp/test_code_action.py
+++ b/tests/lsp/test_code_action.py
@@ -96,7 +96,7 @@ def test_code_action_return_list(client_server):
 
     assert response[0].title == "action1"
     assert response[1].title == "action2"
-    assert response[1].kind == CodeActionKind.Refactor
+    assert response[1].kind == CodeActionKind.Refactor.value
     assert response[2].title == "cmd1"
     assert response[2].command == "cmd1"
     assert response[2].arguments == [1, "two"]


### PR DESCRIPTION
## Description

- The `mypy` issues identified by @dimbleby should now be resolved
- By replacing the `attrs.field()` definitions in the `JsonRPCXXX` type definitions with structure hooks, custom messages should no longer be corrupted, while still retaining the existing `dict_to_object` behavior. Closes #285 
- The module level `converter` in `pygls/protocol.py` has been replaced with one attached to the `JsonRPCProtocol` object's instance which can now be overriden by passing a  custom `converter_factory` to the `Server` object's constructor. Closes #286 



## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [/] Standalone docs have been updated accordingly
- [/] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [/] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
