### PR TITLE
Fix construction of `workspace.fileOperations` server capabilities

### DIFF
--- a/pygls/capabilities.py
+++ b/pygls/capabilities.py
@@ -322,54 +322,23 @@ class ServerCapabilitiesBuilder:
     def _with_workspace_capabilities(self):
         # File operations
         file_operations = FileOperationOptions()
+        operations = [
+            (WORKSPACE_WILL_CREATE_FILES, "will_create"),
+            (WORKSPACE_DID_CREATE_FILES, "did_create"),
+            (WORKSPACE_WILL_DELETE_FILES, "will_delete"),
+            (WORKSPACE_DID_DELETE_FILES, "did_delete"),
+            (WORKSPACE_WILL_RENAME_FILES, "will_rename"),
+            (WORKSPACE_DID_RENAME_FILES, "did_rename"),
+        ]
 
-        will_create = (
-            get_capability(self.client_capabilities, 'workspace.fileOperations.willCreate')
-            if WORKSPACE_WILL_CREATE_FILES in self.features
-            else None
-        )
-        if will_create is not None:
-            file_operations.will_create = will_create
+        for method_name, capability_name in operations:
+            client_supports_method = get_capability(
+                self.client_capabilities, f'workspace.file_operations.{capability_name}'
+            )
 
-        did_create = (
-            get_capability(self.client_capabilities, 'workspace.fileOperations.didCreate')
-            if WORKSPACE_DID_CREATE_FILES in self.features
-            else None
-        )
-        if did_create is not None:
-            file_operations.did_create = did_create
-
-        will_rename = (
-            get_capability(self.client_capabilities, 'workspace.fileOperations.willRename')
-            if WORKSPACE_WILL_RENAME_FILES in self.features
-            else None
-        )
-        if will_rename is not None:
-            file_operations.will_rename = will_rename
-
-        did_rename = (
-            get_capability(self.client_capabilities, 'workspace.fileOperations.didRename')
-            if WORKSPACE_DID_RENAME_FILES in self.features
-            else None
-        )
-        if did_rename is not None:
-            file_operations.did_rename = did_rename
-
-        will_delete = (
-            get_capability(self.client_capabilities, 'workspace.fileOperations.willDelete')
-            if WORKSPACE_WILL_DELETE_FILES in self.features
-            else None
-        )
-        if will_delete is not None:
-            file_operations.will_delete = will_delete
-
-        did_delete = (
-            get_capability(self.client_capabilities, 'workspace.fileOperations.didDelete')
-            if WORKSPACE_DID_DELETE_FILES in self.features
-            else None
-        )
-        if did_delete is not None:
-            file_operations.did_delete = did_delete
+            if client_supports_method:
+                value = self._provider_options(method_name, None)
+                setattr(file_operations, capability_name, value)
 
         self.server_cap.workspace = ServerCapabilitiesWorkspaceType(
             workspace_folders=WorkspaceFoldersServerCapabilities(

--- a/pygls/lsp/__init__.py
+++ b/pygls/lsp/__init__.py
@@ -22,6 +22,13 @@ from lsprotocol.types import (
     TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL,
     TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL_DELTA,
     TEXT_DOCUMENT_SEMANTIC_TOKENS_RANGE,
+    WORKSPACE_DID_CREATE_FILES,
+    WORKSPACE_DID_DELETE_FILES,
+    WORKSPACE_DID_RENAME_FILES,
+    WORKSPACE_WILL_CREATE_FILES,
+    WORKSPACE_WILL_DELETE_FILES,
+    WORKSPACE_WILL_RENAME_FILES,
+    FileOperationRegistrationOptions,
     SemanticTokensLegend,
     SemanticTokensRegistrationOptions,
     ShowDocumentResult
@@ -37,6 +44,12 @@ METHOD_TO_OPTIONS = {
     TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL: Union[SemanticTokensLegend, SemanticTokensRegistrationOptions],
     TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL_DELTA: Union[SemanticTokensLegend, SemanticTokensRegistrationOptions],
     TEXT_DOCUMENT_SEMANTIC_TOKENS_RANGE: Union[SemanticTokensLegend, SemanticTokensRegistrationOptions],
+    WORKSPACE_DID_CREATE_FILES: FileOperationRegistrationOptions,
+    WORKSPACE_DID_DELETE_FILES: FileOperationRegistrationOptions,
+    WORKSPACE_DID_RENAME_FILES: FileOperationRegistrationOptions,
+    WORKSPACE_WILL_CREATE_FILES: FileOperationRegistrationOptions,
+    WORKSPACE_WILL_DELETE_FILES: FileOperationRegistrationOptions,
+    WORKSPACE_WILL_RENAME_FILES: FileOperationRegistrationOptions,
 }
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -7,20 +7,31 @@ from lsprotocol.types import (
     TEXT_DOCUMENT_DID_SAVE,
     TEXT_DOCUMENT_WILL_SAVE,
     TEXT_DOCUMENT_WILL_SAVE_WAIT_UNTIL,
+    WORKSPACE_DID_CREATE_FILES,
+    WORKSPACE_WILL_CREATE_FILES,
+    WORKSPACE_DID_DELETE_FILES,
+    WORKSPACE_WILL_DELETE_FILES,
+    WORKSPACE_DID_RENAME_FILES,
+    WORKSPACE_WILL_RENAME_FILES,
     ClientCapabilities,
+    FileOperationClientCapabilities,
+    FileOperationFilter,
+    FileOperationOptions,
+    FileOperationPattern,
+    FileOperationRegistrationOptions,
     SaveOptions,
     TextDocumentClientCapabilities,
     TextDocumentSaveRegistrationOptions,
     TextDocumentSyncClientCapabilities,
     TextDocumentSyncKind,
     TextDocumentSyncOptions,
+    WorkspaceClientCapabilities,
 )
 
 from pygls.capabilities import ServerCapabilitiesBuilder
 
 
 @pytest.mark.parametrize("capabilities,features,options,expected", [
-
     # textDocument/didOpen
     (
         ClientCapabilities(),
@@ -133,4 +144,290 @@ def test_text_doc_sync_capabilities(
     )
 
     actual = builder.build().text_document_sync
+    assert expected == actual
+
+
+@pytest.mark.parametrize("capabilities,features,options,expected", [
+    (
+        ClientCapabilities(),
+        set(),
+        {},
+        FileOperationOptions()
+    ),
+    # workspace/willCreateFiles
+    (
+        ClientCapabilities(),
+        {WORKSPACE_WILL_CREATE_FILES},
+        {
+            WORKSPACE_WILL_CREATE_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions()
+    ),
+    (
+        ClientCapabilities(
+            workspace=WorkspaceClientCapabilities(
+                file_operations=FileOperationClientCapabilities(
+                    will_create=True
+                )
+            )
+        ),
+        {WORKSPACE_WILL_CREATE_FILES},
+        {
+            WORKSPACE_WILL_CREATE_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions(
+            will_create=FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        )
+    ),
+    # workspace/didCreateFiles
+    (
+        ClientCapabilities(),
+        {WORKSPACE_DID_CREATE_FILES},
+        {
+            WORKSPACE_DID_CREATE_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions()
+    ),
+    (
+        ClientCapabilities(
+            workspace=WorkspaceClientCapabilities(
+                file_operations=FileOperationClientCapabilities(
+                    did_create=True
+                )
+            )
+        ),
+        {WORKSPACE_DID_CREATE_FILES},
+        {
+            WORKSPACE_DID_CREATE_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions(
+            did_create=FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        )
+    ),
+    # workspace/willDeleteFiles
+    (
+        ClientCapabilities(),
+        {WORKSPACE_WILL_DELETE_FILES},
+        {
+            WORKSPACE_WILL_DELETE_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions()
+    ),
+    (
+        ClientCapabilities(
+            workspace=WorkspaceClientCapabilities(
+                file_operations=FileOperationClientCapabilities(
+                    will_delete=True
+                )
+            )
+        ),
+        {WORKSPACE_WILL_DELETE_FILES},
+        {
+            WORKSPACE_WILL_DELETE_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions(
+            will_delete=FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        )
+    ),
+    # workspace/didDeleteFiles
+    (
+        ClientCapabilities(),
+        {WORKSPACE_DID_DELETE_FILES},
+        {
+            WORKSPACE_DID_DELETE_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions()
+    ),
+    (
+        ClientCapabilities(
+            workspace=WorkspaceClientCapabilities(
+                file_operations=FileOperationClientCapabilities(
+                    did_delete=True
+                )
+            )
+        ),
+        {WORKSPACE_DID_DELETE_FILES},
+        {
+            WORKSPACE_DID_DELETE_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions(
+            did_delete=FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        )
+    ),
+    # workspace/willRenameFiles
+    (
+        ClientCapabilities(),
+        {WORKSPACE_WILL_RENAME_FILES},
+        {
+            WORKSPACE_WILL_RENAME_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions()
+    ),
+    (
+        ClientCapabilities(
+            workspace=WorkspaceClientCapabilities(
+                file_operations=FileOperationClientCapabilities(
+                    will_rename=True
+                )
+            )
+        ),
+        {WORKSPACE_WILL_RENAME_FILES},
+        {
+            WORKSPACE_WILL_RENAME_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions(
+            will_rename=FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        )
+    ),
+    # workspace/didRenameFiles
+    (
+        ClientCapabilities(),
+        {WORKSPACE_DID_RENAME_FILES},
+        {
+            WORKSPACE_DID_RENAME_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions()
+    ),
+    (
+        ClientCapabilities(
+            workspace=WorkspaceClientCapabilities(
+                file_operations=FileOperationClientCapabilities(
+                    did_rename=True
+                )
+            )
+        ),
+        {WORKSPACE_DID_RENAME_FILES},
+        {
+            WORKSPACE_DID_RENAME_FILES: FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        },
+        FileOperationOptions(
+            did_rename=FileOperationRegistrationOptions(
+                filters=[
+                    FileOperationFilter(
+                        pattern=FileOperationPattern(glob="**/*.py")
+                    )
+                ]
+            )
+        )
+    ),
+])
+def test_file_operations_capabilities(
+    capabilities: ClientCapabilities,
+    features: Set[str],
+    options,
+    expected: FileOperationOptions
+):
+    """Ensure that `pygls` can correctly construct server capabilities for the file
+    operations set of features."""
+
+    builder = ServerCapabilitiesBuilder(
+        capabilities, features, options, [], TextDocumentSyncKind.Incremental
+    )
+
+    server = builder.build()
+    assert server.workspace is not None
+
+    actual = server.workspace.file_operations
     assert expected == actual


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This fixes the construction of the `workspace.fileOperations` fields of the server's capabilities by passing through the `FileOperationRegistrationOptions` provided when registering features like `WORKSPACE_DID_DELETE_FILES`

This also resolves [the issue](https://github.com/openlawlibrary/pygls/pull/273#issuecomment-1301546322) I was having with the runtime type checking of the given options 

Closes #278 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
