### PR TITLE
Recomend v1 alpha release for new projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 ### Fixed
 
+## [0.13.1] - 1/12/2022
+### Changed
+Docs now state that the v1 alpha branch is the recommended way to start new projects
+### Fixed
+Support `CodeActionKind.SourceFixAll`
+
 ## [0.13.0] - 2/11/2022
 ### Added
 - Add `name` and `version` arguments to the constructor of `LanguageServer` ([#274])

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Note**
+> We will soon release a major version bump with breaking changes. We recommend starting new projects with the v1 alpha release at https://github.com/openlawlibrary/pygls/pull/273
+
 # _pygls_
 
 [![PyPI Version](https://img.shields.io/pypi/v/pygls.svg)](https://pypi.org/project/pygls/) [![Build Status](https://dev.azure.com/openlawlibrary/pygls/_apis/build/status/openlawlibrary.pygls?branchName=master)](https://dev.azure.com/openlawlibrary/pygls/_build/latest?definitionId=2&branchName=master) ![!pyversions](https://img.shields.io/pypi/pyversions/pygls.svg) ![license](https://img.shields.io/pypi/l/pygls.svg) [![Documentation Status](https://img.shields.io/badge/docs-latest-green.svg)](https://pygls.readthedocs.io/en/latest/)

--- a/docs/source/pages/getting_started.rst
+++ b/docs/source/pages/getting_started.rst
@@ -17,6 +17,12 @@ servers that are based on it.
 Installation
 ------------
 
+.. note::
+   *December 2022*
+   We will soon release a major version bump with breaking changes.
+   We recommend starting new projects with the v1 alpha release at:
+   https://github.com/openlawlibrary/pygls/pull/273
+
 To get the latest release from *PyPI*, simply run:
 
 .. code:: console

--- a/pygls/__init__.py
+++ b/pygls/__init__.py
@@ -19,7 +19,7 @@
 import os
 import sys
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 IS_WIN = os.name == 'nt'
 IS_PYODIDE = 'pyodide' in sys.modules

--- a/pygls/lsp/types/language_features/code_action.py
+++ b/pygls/lsp/types/language_features/code_action.py
@@ -44,6 +44,7 @@ class CodeActionKind(str, enum.Enum):
     RefactorRewrite = 'refactor.rewrite'
     Source = 'source'
     SourceOrganizeImports = 'source.organizeImports'
+    SourceFixAll = 'source.fixAll'
 
 
 class CodeActionLiteralSupportActionKindClientCapabilities(Model):


### PR DESCRIPTION
Add doc/README updates to recommend the v1 alpha release for new projects.

This came up in #293 where a missing feature was identified in the current release, but is fixed in the v1 alpha release. Whereas we're only _probably_ ready to release v1, we're _definitely_ ready to recommend it for new projects. 

Missing feature notes:
Strictly, Pygls only currently supports LSP v3.15, but this feature was added in 3.17. Ideally we wouldn't mix and match features from different versions. Ideally we should wholesale support a version. Anyway, we're soon to release a breaking change version of Pygls that follows Microsofts own Python LSP types #273.

Fixes #293

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
