### PR TITLE
Make `name` and `version` arguments mandatory

### DIFF
--- a/docs/source/pages/migrating-to-v1.rst
+++ b/docs/source/pages/migrating-to-v1.rst
@@ -180,13 +180,25 @@ You can then override the default converter used by ``pygls`` when constructing 
 .. code-block:: python
 
    server = LanguageServer(
-       name="my-language-server", version="1.0", converter_factory=custom_converter
+       name="my-language-server", version="v1.0", converter_factory=custom_converter
    )
 
 See the `hooks.py`_ module in ``lsprotocol`` for some example structure hooks
 
 Miscellaneous
 -------------
+
+Mandatory ``name`` and ``version``
+""""""""""""""""""""""""""""""""""
+
+It is now necessary to provide a name and version when constructing an instance of the ``LanguageServer`` class
+
+.. code-block:: python
+
+   from pygls.server import LanguageServer
+
+   server = LanguageServer(name="my-language-server", version="v1.0")
+
 
 ``ClientCapabilities.get_capability`` is now ``get_capability``
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -663,16 +663,10 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         from pygls.progress import Progress
         self.progress = Progress(self)
 
-        if server.name is None or server.version is None:
-            self.server_info = None
-            logger.warning("Name or version is not set. "
-                           "This will be mandatory: "
-                           "https://github.com/openlawlibrary/pygls/pull/276")
-        else:
-            self.server_info = InitializeResultServerInfoType(
-                name=server.name,
-                version=server.version,
-            )
+        self.server_info = InitializeResultServerInfoType(
+            name=server.name,
+            version=server.version,
+        )
 
         self._register_builtin_features()
 

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -341,8 +341,8 @@ class LanguageServer(Server):
 
     def __init__(
         self,
-        name: str = None,
-        version: str = None,
+        name: str,
+        version: str,
         loop=None,
         protocol_cls=LanguageServerProtocol,
         converter_factory=default_converter,

--- a/tests/test_server_connection.py
+++ b/tests/test_server_connection.py
@@ -94,7 +94,7 @@ async def test_ws_server():
     """Smoke test to ensure we can send/receive messages over websockets"""
 
     loop = asyncio.new_event_loop()
-    server = LanguageServer(loop=loop)
+    server = LanguageServer('pygls-test', 'v1', loop=loop)
 
     # Run the server over Websockets in a separate thread
     server_thread = Thread(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

I think in #274  we said we wanted to make the `name` and `version` arguments to a `LanguageServer` object mandatory?
This PR removes the warning and default arguments meaning they now have to be provided by the language server author.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
