### PR TITLE
Fix 'ConfigurationParams' object has no attribute 'partial_result_token errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 ### Fixed
 
- - Fix progress example in json extension. ([#230]) 
+ - Fix progress example in json extension. ([#230])
+ - Fix `AttributeErrors` in `get_configuration_async`, `get_configuration_callback`, `get_configuration_threaded` commands in json extension. ([#307])
+ - Fix type annotations for `get_configuration_async` and `get_configuration` methods on `LanguageServer` and `LanguageServerProtocol` objects ([#307])
 
 [#230]: https://github.com/openlawlibrary/pygls/issues/230
+[#307]: https://github.com/openlawlibrary/pygls/issues/307
+
 
 ## [1.0.0] - 2/12/2022
 ### Changed

--- a/docs/source/pages/advanced_usage.rst
+++ b/docs/source/pages/advanced_usage.rst
@@ -324,7 +324,7 @@ The code snippet below shows how to send configuration to the client:
 .. code:: python
 
     def get_configuration(self,
-                          params: ConfigurationParams,
+                          params: WorkspaceConfigurationParams,
                           callback: Optional[Callable[[List[Any]], None]] = None
                           ) -> asyncio.Future:
         # Omitted
@@ -338,7 +338,7 @@ client, depending on way how the function is registered (described
 .. code:: python
 
     # await keyword tells event loop to switch to another task until notification is received
-    config = await ls.get_configuration(ConfigurationParams(items=[ConfigurationItem(scope_uri='doc_uri_here', section='section')]))
+    config = await ls.get_configuration(WorkspaceConfigurationParams(items=[ConfigurationItem(scope_uri='doc_uri_here', section='section')]))
 
 -  *synchronous* functions
 
@@ -348,14 +348,14 @@ client, depending on way how the function is registered (described
     def callback(config):
         # Omitted
 
-    config = ls.get_configuration(ConfigurationParams(items=[ConfigurationItem(scope_uri='doc_uri_here', section='section')]), callback)
+    config = ls.get_configuration(WorkspaceConfigurationParams(items=[ConfigurationItem(scope_uri='doc_uri_here', section='section')]), callback)
 
 -  *threaded* functions
 
 .. code:: python
 
     # .result() will block the thread
-    config = ls.get_configuration(ConfigurationParams(items=[ConfigurationItem(scope_uri='doc_uri_here', section='section')])).result()
+    config = ls.get_configuration(WorkspaceConfigurationParams(items=[ConfigurationItem(scope_uri='doc_uri_here', section='section')])).result()
 
 Show Message
 ^^^^^^^^^^^^

--- a/examples/json-extension/server/server.py
+++ b/examples/json-extension/server/server.py
@@ -26,16 +26,17 @@ from lsprotocol.types import (TEXT_DOCUMENT_COMPLETION, TEXT_DOCUMENT_DID_CHANGE
                                TEXT_DOCUMENT_DID_CLOSE, TEXT_DOCUMENT_DID_OPEN,
                                TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL)
 from lsprotocol.types import (CompletionItem, CompletionList, CompletionOptions,
-                             CompletionParams, ConfigurationItem,
-                             ConfigurationParams, Diagnostic,
-                             DidChangeTextDocumentParams,
-                             DidCloseTextDocumentParams,
-                             DidOpenTextDocumentParams, MessageType, Position,
-                             Range, Registration, RegistrationParams,
-                             SemanticTokens, SemanticTokensLegend, SemanticTokensParams,
-                             Unregistration, UnregistrationParams,
-                             WorkDoneProgressBegin, WorkDoneProgressEnd,
-                             WorkDoneProgressReport)
+                              CompletionParams, ConfigurationItem,
+                              Diagnostic,
+                              DidChangeTextDocumentParams,
+                              DidCloseTextDocumentParams,
+                              DidOpenTextDocumentParams, MessageType, Position,
+                              Range, Registration, RegistrationParams,
+                              SemanticTokens, SemanticTokensLegend, SemanticTokensParams,
+                              Unregistration, UnregistrationParams,
+                              WorkDoneProgressBegin, WorkDoneProgressEnd,
+                              WorkDoneProgressReport,
+                              WorkspaceConfigurationParams)
 from pygls.server import LanguageServer
 
 COUNT_DOWN_START_IN_SECONDS = 10
@@ -235,7 +236,7 @@ async def show_configuration_async(ls: JsonLanguageServer, *args):
     """Gets exampleConfiguration from the client settings using coroutines."""
     try:
         config = await ls.get_configuration_async(
-            ConfigurationParams(items=[
+            WorkspaceConfigurationParams(items=[
                 ConfigurationItem(
                     scope_uri='',
                     section=JsonLanguageServer.CONFIGURATION_SECTION)
@@ -261,11 +262,16 @@ def show_configuration_callback(ls: JsonLanguageServer, *args):
         except Exception as e:
             ls.show_message_log(f'Error ocurred: {e}')
 
-    ls.get_configuration(ConfigurationParams(items=[
-        ConfigurationItem(
-            scope_uri='',
-            section=JsonLanguageServer.CONFIGURATION_SECTION)
-    ]), _config_callback)
+    ls.get_configuration(
+        WorkspaceConfigurationParams(
+            items=[
+                ConfigurationItem(
+                    scope_uri='',
+                    section=JsonLanguageServer.CONFIGURATION_SECTION)
+            ]
+        ),
+        _config_callback
+    )
 
 
 @json_server.thread()
@@ -273,7 +279,7 @@ def show_configuration_callback(ls: JsonLanguageServer, *args):
 def show_configuration_thread(ls: JsonLanguageServer, *args):
     """Gets exampleConfiguration from the client settings using thread pool."""
     try:
-        config = ls.get_configuration(ConfigurationParams(items=[
+        config = ls.get_configuration(WorkspaceConfigurationParams(items=[
             ConfigurationItem(
                 scope_uri='',
                 section=JsonLanguageServer.CONFIGURATION_SECTION)

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -55,7 +55,7 @@ from lsprotocol.types import (
 )
 from lsprotocol.types import (
     ApplyWorkspaceEditParams,
-    ConfigurationParams, Diagnostic,
+    Diagnostic,
     DidChangeTextDocumentParams, DidChangeWorkspaceFoldersParams,
     DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     ExecuteCommandParams, InitializeParams, InitializeResult,
@@ -63,7 +63,8 @@ from lsprotocol.types import (
     RegistrationParams, ResponseErrorMessage, SetTraceParams,
     ShowDocumentParams, ShowMessageParams,
     TraceValues, UnregistrationParams, WorkspaceApplyEditResponse,
-    WorkspaceEdit, InitializeResultServerInfoType
+    WorkspaceEdit, InitializeResultServerInfoType,
+    WorkspaceConfigurationParams
 )
 from pygls.uris import from_fs_path
 from pygls.workspace import Workspace
@@ -799,12 +800,12 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         cmd_handler = self.fm.commands[params.command]
         self._execute_request(msg_id, cmd_handler, params.arguments)
 
-    def get_configuration(self, params: ConfigurationParams,
+    def get_configuration(self, params: WorkspaceConfigurationParams,
                           callback: Optional[ConfigCallbackType] = None) -> Future:
         """Sends configuration request to the client.
 
         Args:
-            params(ConfigurationParams): ConfigurationParams from lsp specs
+            params(WorkspaceConfigurationParams): WorkspaceConfigurationParams from lsp specs
             callback(callable): Callabe which will be called after
                                 response from the client is received
         Returns:
@@ -813,11 +814,11 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         """
         return self.send_request(WORKSPACE_CONFIGURATION, params, callback)
 
-    def get_configuration_async(self, params: ConfigurationParams) -> asyncio.Future:
+    def get_configuration_async(self, params: WorkspaceConfigurationParams) -> asyncio.Future:
         """Calls `get_configuration` method but designed to use with coroutines
 
         Args:
-            params(ConfigurationParams): ConfigurationParams from lsp specs
+            params(WorkspaceConfigurationParams): WorkspaceConfigurationParams from lsp specs
         Returns:
             asyncio.Future that can be awaited
         """

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -28,10 +28,11 @@ from pygls.lsp import ConfigCallbackType, ShowDocumentCallbackType
 from pygls.exceptions import PyglsError, JsonRpcException, FeatureRequestError
 from lsprotocol.types import (
     ClientCapabilities,
-    ConfigurationParams, Diagnostic, MessageType, RegistrationParams,
+    Diagnostic, MessageType, RegistrationParams,
     ServerCapabilities, ShowDocumentParams,
     TextDocumentSyncKind, UnregistrationParams,
-    WorkspaceApplyEditResponse, WorkspaceEdit
+    WorkspaceApplyEditResponse, WorkspaceEdit,
+    WorkspaceConfigurationParams
 )
 from pygls.progress import Progress
 from pygls.protocol import LanguageServerProtocol, default_converter
@@ -389,12 +390,12 @@ class LanguageServer(Server):
         """
         return self.lsp.fm.feature(feature_name, options)
 
-    def get_configuration(self, params: ConfigurationParams,
+    def get_configuration(self, params: WorkspaceConfigurationParams,
                           callback: Optional[ConfigCallbackType] = None) -> Future:
         """Gets the configuration settings from the client."""
         return self.lsp.get_configuration(params, callback)
 
-    def get_configuration_async(self, params: ConfigurationParams) -> asyncio.Future:
+    def get_configuration_async(self, params: WorkspaceConfigurationParams) -> asyncio.Future:
         """Gets the configuration settings from the client. Should be called with `await`"""
         return self.lsp.get_configuration_async(params)
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

It turns out the `workspace/configuration` request requires a `WorkspaceConfigurationParams` object, rather than a plain `ConfigurationParams` object. 

This PR
- Fixes the `AttributeErrors` seen in the various `get_configuration_xxx` commands in the example json extension, as well as adding test cases to cover them going forward. 
 - Fixes the type annotations in the various `get_configuration_xxx` methods in the pygls codebase
- Updates the documentation to match

Fixes #307 

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [/] Docstrings have been included and/or updated, as appropriate
- [/] Standalone docs have been updated accordingly
- [/] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
