### PR TITLE
Remove incorrect data files definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,20 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 ### Fixed
 
+- Data files are no longer placed inside the wrong `site-packages` folder when installing `pygls` ([#232])
+
+[#232]: https://github.com/openlawlibrary/pygls/issues/232
+
+
 ## [1.0.1] - February 16th, 2023
 ### Fixed
 
  - Fix progress example in json extension. ([#230])
  - Fix `AttributeErrors` in `get_configuration_async`, `get_configuration_callback`, `get_configuration_threaded` commands in json extension. ([#307])
  - Fix type annotations for `get_configuration_async` and `get_configuration` methods on `LanguageServer` and `LanguageServerProtocol` objects ([#307])
- - Provide `version` param for publishing diagnostics ([#303]) 
+ - Provide `version` param for publishing diagnostics ([#303])
  - Relaxed the Python version upper bound to `<4` ([#318])
- 
+
 [#230]: https://github.com/openlawlibrary/pygls/issues/230
 [#303]: https://github.com/openlawlibrary/pygls/issues/303
 [#307]: https://github.com/openlawlibrary/pygls/issues/307

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,11 +61,6 @@ test =
     pytest==7.1.2
     pytest-asyncio==0.18.3
 
-[options.data_files] =
-lib/site-packages/pygls =
-    ThirdPartyNotices.txt
-    ./pygls/py.typed
-
 [flake8]
 max-line-length = 99
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

I've been playing around with using `pyright` as a language server recently and have been bitten by the issue described in #232. Removing the `data_files` definition from `setup.cfg` seems to fix the issue.

As far as I can tell it doesn't break the packaging either as the `py.typed`  and `ThirdPatyNotices.txt` files are still included thanks to the declarations in `MANIFEST.in`

Closes #232 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
