### PR TITLE
Drop mock dependency

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 - [Dillan Mills](https://github.com/DillanCMills)
 - [Felicián Németh](https://github.com/nemethf)
 - [Felix Yan](https://github.com/felixonmars)
+- [Jelle van der Waa](https://github.com/jelly)
 - [Jérome Perrin](https://github.com/perrinjerome)
 - [Karthik Nadig](https://github.com/karthiknadig)
 - [Laurence Warne](https://github.com/LaurenceWarne)

--- a/examples/json-vscode-extension/server/tests/unit/test_features.py
+++ b/examples/json-vscode-extension/server/tests/unit/test_features.py
@@ -21,7 +21,7 @@ import threading
 import time
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from lsprotocol.types import (DidCloseTextDocumentParams,
                               DidOpenTextDocumentParams, TextDocumentIdentifier,
                               WorkspaceConfigurationResponse,

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     typeguard>=3,<4
 include_package_data = True
 tests_require =
-    mock==4.0.3
     pytest==7.1.2
     pytest-asyncio==0.18.3
 
@@ -57,7 +56,6 @@ docs =
     sphinx==5.0.1
     sphinx_rtd_theme==1.0.0
 test =
-    mock==4.0.3
     pytest==7.1.2
     pytest-asyncio==0.18.3
 


### PR DESCRIPTION
Part of the tests already use unittest.mock so switch the last mock module user over and drop the mock test dependency.

## Description (e.g. "Related to ...", etc.)

Drop mock dependency 

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [/] Docstrings have been included and/or updated, as appropriate
- [/] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [/] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
