### PR TITLE
Ensure that `pygls.Server` uses the event loop it is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,17 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 ### Fixed
 
+- `pygls` no longer overrides the event loop for the current thread when given an explicit loop to use. ([#334])
+
+[#334]: https://github.com/openlawlibrary/pygls/issues/334
+
+
 ## [1.0.2] - May 15th, 2023
 ### Changed
 - Update typeguard to 3.x ([#327])
+
+[#327]: https://github.com/openlawlibrary/pygls/issues/327
+
 
 ### Fixed
 - Data files are no longer placed inside the wrong `site-packages` folder when installing `pygls` ([#232])


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Before this commit `pygls` would override the event loop for the current thread even when given an existing loop to use.

Now `pygls` will rely on `asyncio.new_event_loop` to create the appropriate event loop for the platform and only call it when `loop=None`

This commit also introduces the `_own_loop` flag which is used to make sure `pygls` does not close an event loop it does not own.

Related: #334 

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [/] Tests have been included and/or updated, as appropriate
- [/] Docstrings have been included and/or updated, as appropriate
- [/] Standalone docs have been updated accordingly
- [/] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
