### PR TITLE
docs: fix broken link and outdated comment

### DIFF
--- a/docs/source/pages/advanced_usage.rst
+++ b/docs/source/pages/advanced_usage.rst
@@ -105,8 +105,9 @@ What is a feature in *pygls*? In terms of language servers and the
 `Language Server Protocol <https://microsoft.github.io/language-server-protocol/>`__,
 a feature is one of the predefined methods from
 LSP `specification <https://microsoft.github.io/language-server-protocol/specification>`__,
-such as: *code completion*, *formatting*, *code lens*, etc. Features
-that are available can be found in `pygls.lsp.methods`_ module.
+such as: *code completion*, *formatting*, *code lens*, etc. See the `lsprotocol
+<https://github.com/microsoft/lsprotocol/blob/main/packages/python/lsprotocol/types.py>`_ module
+for the complete and canonical list of available features.
 
 *Built-In* Features
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/pages/getting_started.rst
+++ b/docs/source/pages/getting_started.rst
@@ -78,7 +78,7 @@ Register Features and Commands
    def cmd_return_hello_world(ls, *args):
        return 'Hello World!'
 
-See the `lsprotocol`_ module for the complete and canonical list of avaiable features.
+See the `lsprotocol`_ module for the complete and canonical list of available features.
 
 Advanced usage
 --------------
@@ -94,4 +94,4 @@ haven't worked with language servers before.
 
 
 .. _GitHub: https://github.com/openlawlibrary/pygls
-.. _lsprotocol: https://github.com/microsoft/lsprotocol/blob/main/lsprotocol/types.py
+.. _lsprotocol: https://github.com/microsoft/lsprotocol/blob/main/packages/python/lsprotocol/types.py


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Fixes a broken link to `lsprotocol` in the docs, as well as an outdated comment (I think) pointing to `pygls.lsp.methods` which should point to `lsprotocol` too. Also a typo.

It's such a small change that I don't think contributors or changelog need to be updated.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md