### PR TITLE
Add `await` syntax support for sending edit request to client

### DIFF
--- a/docs/source/pages/advanced_usage.rst
+++ b/docs/source/pages/advanced_usage.rst
@@ -488,7 +488,8 @@ Workspace methods that can be used for user defined features are:
 
     def apply_edit(self, edit: WorkspaceEdit, label: str = None) -> ApplyWorkspaceEditResponse:
         # Omitted
-
+    def apply_edit_async(self, edit: WorkspaceEdit, label: str = None) -> ApplyWorkspaceEditResponse:
+        # Omitted
 
 .. _pygls.lsp.methods: https://github.com/openlawlibrary/pygls/blob/master/pygls/lsp/methods.py
 .. _pygls.lsp.types: https://github.com/openlawlibrary/pygls/tree/master/pygls/lsp/types

--- a/pygls/protocol.py
+++ b/pygls/protocol.py
@@ -742,6 +742,14 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
             WORKSPACE_APPLY_EDIT, ApplyWorkspaceEditParams(edit=edit, label=label)
         )
 
+    def apply_edit_async(
+        self, edit: WorkspaceEdit, label: Optional[str] = None
+    ) -> WorkspaceApplyEditResponse:
+        """Sends apply edit request to the client. Should be called with `await`"""
+        return self.send_request_async(
+            WORKSPACE_APPLY_EDIT, ApplyWorkspaceEditParams(edit=edit, label=label)
+        )
+
     @lsp_method(EXIT)
     def lsp_exit(self, *args) -> None:
         """Stops the server process."""

--- a/pygls/server.py
+++ b/pygls/server.py
@@ -378,6 +378,12 @@ class LanguageServer(Server):
         """Sends apply edit request to the client."""
         return self.lsp.apply_edit(edit, label)
 
+    def apply_edit_async(
+        self, edit: WorkspaceEdit, label: Optional[str] = None
+    ) -> WorkspaceApplyEditResponse:
+        """Sends apply edit request to the client. Should be called with `await`"""
+        return self.lsp.apply_edit_async(edit, label)
+
     def command(self, command_name: str) -> Callable[[F], F]:
         """Decorator used to register custom commands.
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Before:
```python
def edit_callback(future):
    result = future.result()
ls.apply_edit(workspace_edit).add_done_callback(edit_callback)
```

After:
```python
result = await ls.apply_edit_async(workspace_edit)
```

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] [CONTRIBUTORS.md][contributors] was updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/pygls/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
[contributors]: https://github.com/openlawlibrary/pygls/blob/master/CONTRIBUTORS.md
