### PR TITLE
build(deps): lock min Python version to 3.7.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache 2.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.7.16,<4"
+python = ">=3.7.9,<4"
 lsprotocol = "2023.0.0a2"
 typeguard = "^3.0.0"
 websockets = {version = "^11.0.3", optional = true}


### PR DESCRIPTION
Github Actions for windows uses Python 3.7.9 not 3.7.16. This wasn't picked up in the PR that introduced the original lock because of dependency caching. See:

https://github.com/openlawlibrary/pygls/actions/runs/5702563535/job/15454396739#step:6:12

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://chris.beams.io/posts/git-commit/
