### PR TITLE
ci: retry Pyodide tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,13 @@ jobs:
           sudo apt install chromium-browser chromium-chromedriver
           poetry install --with pyodide
       - name: Run Testsuite
-        run: |
-          source $VENV
-          poe test-pyodide
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: |
+            source $VENV
+            poe test-pyodide
 
   lint:
     needs: pre_job


### PR DESCRIPTION
This is to get around a curious issue that isn't resolved by dependency locking. The flakey error is:

`ImportError: cannot import name 'Any' from 'typing_extensions'`

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://chris.beams.io/posts/git-commit/
