### PR TITLE
Rename client objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,6 @@ jobs:
       - name: Install Dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
-          sudo apt update
-          sudo apt install chromium-browser chromium-chromedriver
           poetry install --with pyodide
       - name: Run Testsuite
         uses: nick-fields/retry@v2

--- a/commitlintrc.yaml
+++ b/commitlintrc.yaml
@@ -10,7 +10,7 @@
 #   - '@commitlint/config-conventional'
 rules:
   body-leading-blank: [1, always]
-  body-max-line-length: [2, always, 100]
+  body-max-line-length: [2, always, Infinity]
   footer-leading-blank: [1, always]
   footer-max-line-length: [2, always, 100]
   header-max-length: [2, always, 100]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Features
    -  functions that will be executed in separate thread
 
 -  thread management
--  in-memory workspace with _full_ and _incremental_ document updates
+-  in-memory workspace with *full* and *incremental* document updates
 -  type-checking
 -  good test coverage
 
@@ -43,6 +43,7 @@ User Guide
    pages/advanced_usage
    pages/testing
    pages/migrating-to-v1
+   pages/reference
 
 
 .. _Language Server Protocol: https://microsoft.github.io/language-server-protocol/specification

--- a/docs/source/pages/reference.rst
+++ b/docs/source/pages/reference.rst
@@ -1,0 +1,8 @@
+Reference
+=========
+
+.. toctree::
+   :glob:
+   :maxdepth: 2
+
+   reference/*

--- a/docs/source/pages/reference/clients.rst
+++ b/docs/source/pages/reference/clients.rst
@@ -1,0 +1,8 @@
+Clients
+=======
+
+.. autoclass:: pygls.lsp.client.BaseLanguageClient
+   :members:
+
+.. autoclass:: pygls.client.JsonRPCClient
+   :members:

--- a/docs/source/pages/reference/types.rst
+++ b/docs/source/pages/reference/types.rst
@@ -1,0 +1,7 @@
+Types
+=====
+
+LSP type definitions in ``pygls`` are provided by the `lsprotocol <https://github.com/microsoft/lsprotocol>`__ library
+
+.. automodule:: lsprotocol.types
+   :members:

--- a/poetry.lock
+++ b/poetry.lock
@@ -301,13 +301,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.6"
+version = "8.1.7"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
-    {file = "click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 
 [package.dependencies]
@@ -338,13 +338,13 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.2"
+version = "1.1.3"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
-    {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
 ]
 
 [package.extras]
@@ -436,13 +436,13 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "lsprotocol"
-version = "2023.0.0a2"
+version = "2023.0.0a3"
 description = "Python implementation of the Language Server Protocol."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "lsprotocol-2023.0.0a2-py3-none-any.whl", hash = "sha256:c4f2f77712b50d065b17f9b50d2b88c480dc2ce4bbaa56eea8269dbf54bc9701"},
-    {file = "lsprotocol-2023.0.0a2.tar.gz", hash = "sha256:80aae7e39171b49025876a524937c10be2eb986f4be700ca22ee7d186b8488aa"},
+    {file = "lsprotocol-2023.0.0a3-py3-none-any.whl", hash = "sha256:2896c5a30c34846e3d5687e35715961f49bf7b92a36e4fb2b707ff65f19087f7"},
+    {file = "lsprotocol-2023.0.0a3.tar.gz", hash = "sha256:d704e4e00419f74bece9795de4b34d02aa555fc0131fec49f59ac9eb46816e51"},
 ]
 
 [package.dependencies]
@@ -691,13 +691,13 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.15.1"
+version = "2.16.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
-    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
+    {file = "Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
+    {file = "Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
 ]
 
 [package.extras]
@@ -819,13 +819,13 @@ files = [
 
 [[package]]
 name = "selenium"
-version = "4.10.0"
+version = "4.11.2"
 description = ""
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "selenium-4.10.0-py3-none-any.whl", hash = "sha256:40241b9d872f58959e9b34e258488bf11844cd86142fd68182bd41db9991fc5c"},
-    {file = "selenium-4.10.0.tar.gz", hash = "sha256:871bf800c4934f745b909c8dfc7d15c65cf45bd2e943abd54451c810ada395e3"},
+    {file = "selenium-4.11.2-py3-none-any.whl", hash = "sha256:98e72117b194b3fa9c69b48998f44bf7dd4152c7bd98544911a1753b9f03cc7d"},
+    {file = "selenium-4.11.2.tar.gz", hash = "sha256:9f9a5ed586280a3594f7461eb1d9dab3eac9d91e28572f365e9b98d9d03e02b5"},
 ]
 
 [package.dependencies]
@@ -904,18 +904,18 @@ test = ["cython", "html5lib", "pytest (>=4.6)", "typed_ast"]
 
 [[package]]
 name = "sphinx-rtd-theme"
-version = "1.2.2"
+version = "1.3.0"
 description = "Read the Docs theme for Sphinx"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "sphinx_rtd_theme-1.2.2-py2.py3-none-any.whl", hash = "sha256:6a7e7d8af34eb8fc57d52a09c6b6b9c46ff44aea5951bc831eeb9245378f3689"},
-    {file = "sphinx_rtd_theme-1.2.2.tar.gz", hash = "sha256:01c5c5a72e2d025bd23d1f06c59a4831b06e6ce6c01fdd5ebfe9986c0a880fc7"},
+    {file = "sphinx_rtd_theme-1.3.0-py2.py3-none-any.whl", hash = "sha256:46ddef89cc2416a81ecfbeaceab1881948c014b1b6e4450b815311a89fb977b0"},
+    {file = "sphinx_rtd_theme-1.3.0.tar.gz", hash = "sha256:590b030c7abb9cf038ec053b95e5380b5c70d61591eb0b552063fbe7c41f0931"},
 ]
 
 [package.dependencies]
 docutils = "<0.19"
-sphinx = ">=1.6,<7"
+sphinx = ">=1.6,<8"
 sphinxcontrib-jquery = ">=4,<5"
 
 [package.extras]
@@ -1284,5 +1284,5 @@ ws = ["websockets"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7.16,<4"
-content-hash = "0963df26c51f1bebf513af40b40cf9030252bb20b90aa8724beb7e128da138ed"
+python-versions = ">=3.7.9,<4"
+content-hash = "27ee5cd8b82f9c490eed22daa698893ebaed1bd98c080ad314545e168298b6e9"

--- a/pygls/client.py
+++ b/pygls/client.py
@@ -97,10 +97,18 @@ class JsonRPCClient:
     ):
         """Decorator used to register LSP features.
 
-        Example:
-            @ls.feature('window/logMessage')
-            def completions(ls, params: LogMessageParams):
-                logger.info("%s", params.message)
+        Example
+        -------
+        ::
+
+           import logging
+           from pygls.client import JsonRPCClient
+
+           ls = JsonRPCClient()
+
+           @ls.feature('window/logMessage')
+           def completions(ls, params):
+               logging.info("%s", params.message)
         """
         return self.protocol.fm.feature(feature_name, options)
 

--- a/pygls/client.py
+++ b/pygls/client.py
@@ -71,7 +71,7 @@ async def aio_readline(stop_event, reader, message_handler):
             content_length = 0
 
 
-class Client:
+class JsonRPCClient:
     """Base JSON-RPC client."""
 
     def __init__(

--- a/pygls/lsp/client.py
+++ b/pygls/lsp/client.py
@@ -1,106 +1,8 @@
 # GENERATED FROM scripts/gen-client.py -- DO NOT EDIT
 # flake8: noqa
 from concurrent.futures import Future
-from lsprotocol.types import CallHierarchyIncomingCall
-from lsprotocol.types import CallHierarchyIncomingCallsParams
-from lsprotocol.types import CallHierarchyItem
-from lsprotocol.types import CallHierarchyOutgoingCall
-from lsprotocol.types import CallHierarchyOutgoingCallsParams
-from lsprotocol.types import CallHierarchyPrepareParams
-from lsprotocol.types import CancelParams
-from lsprotocol.types import CodeAction
-from lsprotocol.types import CodeActionParams
-from lsprotocol.types import CodeLens
-from lsprotocol.types import CodeLensParams
-from lsprotocol.types import ColorInformation
-from lsprotocol.types import ColorPresentation
-from lsprotocol.types import ColorPresentationParams
-from lsprotocol.types import Command
-from lsprotocol.types import CompletionItem
-from lsprotocol.types import CompletionList
-from lsprotocol.types import CompletionParams
-from lsprotocol.types import CreateFilesParams
-from lsprotocol.types import DeclarationParams
-from lsprotocol.types import DefinitionParams
-from lsprotocol.types import DeleteFilesParams
-from lsprotocol.types import DidChangeConfigurationParams
-from lsprotocol.types import DidChangeNotebookDocumentParams
-from lsprotocol.types import DidChangeTextDocumentParams
-from lsprotocol.types import DidChangeWatchedFilesParams
-from lsprotocol.types import DidChangeWorkspaceFoldersParams
-from lsprotocol.types import DidCloseNotebookDocumentParams
-from lsprotocol.types import DidCloseTextDocumentParams
-from lsprotocol.types import DidOpenNotebookDocumentParams
-from lsprotocol.types import DidOpenTextDocumentParams
-from lsprotocol.types import DidSaveNotebookDocumentParams
-from lsprotocol.types import DidSaveTextDocumentParams
-from lsprotocol.types import DocumentColorParams
-from lsprotocol.types import DocumentDiagnosticParams
-from lsprotocol.types import DocumentFormattingParams
-from lsprotocol.types import DocumentHighlight
-from lsprotocol.types import DocumentHighlightParams
-from lsprotocol.types import DocumentLink
-from lsprotocol.types import DocumentLinkParams
-from lsprotocol.types import DocumentOnTypeFormattingParams
-from lsprotocol.types import DocumentRangeFormattingParams
-from lsprotocol.types import DocumentSymbol
-from lsprotocol.types import DocumentSymbolParams
-from lsprotocol.types import ExecuteCommandParams
-from lsprotocol.types import FoldingRange
-from lsprotocol.types import FoldingRangeParams
-from lsprotocol.types import Hover
-from lsprotocol.types import HoverParams
-from lsprotocol.types import ImplementationParams
-from lsprotocol.types import InitializeParams
-from lsprotocol.types import InitializeResult
-from lsprotocol.types import InitializedParams
-from lsprotocol.types import InlayHint
-from lsprotocol.types import InlayHintParams
-from lsprotocol.types import InlineValueEvaluatableExpression
-from lsprotocol.types import InlineValueParams
-from lsprotocol.types import InlineValueText
-from lsprotocol.types import InlineValueVariableLookup
-from lsprotocol.types import LinkedEditingRangeParams
-from lsprotocol.types import LinkedEditingRanges
-from lsprotocol.types import Location
-from lsprotocol.types import LocationLink
-from lsprotocol.types import Moniker
-from lsprotocol.types import MonikerParams
-from lsprotocol.types import PrepareRenameParams
-from lsprotocol.types import PrepareRenameResult_Type1
-from lsprotocol.types import PrepareRenameResult_Type2
-from lsprotocol.types import ProgressParams
-from lsprotocol.types import Range
-from lsprotocol.types import ReferenceParams
-from lsprotocol.types import RelatedFullDocumentDiagnosticReport
-from lsprotocol.types import RelatedUnchangedDocumentDiagnosticReport
-from lsprotocol.types import RenameFilesParams
-from lsprotocol.types import RenameParams
-from lsprotocol.types import SelectionRange
-from lsprotocol.types import SelectionRangeParams
-from lsprotocol.types import SemanticTokens
-from lsprotocol.types import SemanticTokensDelta
-from lsprotocol.types import SemanticTokensDeltaParams
-from lsprotocol.types import SemanticTokensParams
-from lsprotocol.types import SemanticTokensRangeParams
-from lsprotocol.types import SetTraceParams
-from lsprotocol.types import SignatureHelp
-from lsprotocol.types import SignatureHelpParams
-from lsprotocol.types import SymbolInformation
-from lsprotocol.types import TextEdit
-from lsprotocol.types import TypeDefinitionParams
-from lsprotocol.types import TypeHierarchyItem
-from lsprotocol.types import TypeHierarchyPrepareParams
-from lsprotocol.types import TypeHierarchySubtypesParams
-from lsprotocol.types import TypeHierarchySupertypesParams
-from lsprotocol.types import WillSaveTextDocumentParams
-from lsprotocol.types import WorkDoneProgressCancelParams
-from lsprotocol.types import WorkspaceDiagnosticParams
-from lsprotocol.types import WorkspaceDiagnosticReport
-from lsprotocol.types import WorkspaceEdit
-from lsprotocol.types import WorkspaceSymbol
-from lsprotocol.types import WorkspaceSymbolParams
-from pygls.client import Client
+from lsprotocol import types
+from pygls.client import JsonRPCClient
 from pygls.protocol import LanguageServerProtocol
 from pygls.protocol import default_converter
 from typing import Any
@@ -110,7 +12,7 @@ from typing import Optional
 from typing import Union
 
 
-class LanguageClient(Client):
+class BaseLanguageClient(JsonRPCClient):
 
     def __init__(
         self,
@@ -126,8 +28,8 @@ class LanguageClient(Client):
 
     def call_hierarchy_incoming_calls(
         self,
-        params: CallHierarchyIncomingCallsParams,
-        callback: Optional[Callable[[Optional[List[CallHierarchyIncomingCall]]], None]] = None,
+        params: types.CallHierarchyIncomingCallsParams,
+        callback: Optional[Callable[[Optional[List[types.CallHierarchyIncomingCall]]], None]] = None,
     ) -> Future:
         """Make a ``callHierarchy/incomingCalls`` request.
 
@@ -142,8 +44,8 @@ class LanguageClient(Client):
 
     async def call_hierarchy_incoming_calls_async(
         self,
-        params: CallHierarchyIncomingCallsParams,
-    ) -> Optional[List[CallHierarchyIncomingCall]]:
+        params: types.CallHierarchyIncomingCallsParams,
+    ) -> Optional[List[types.CallHierarchyIncomingCall]]:
         """Make a ``callHierarchy/incomingCalls`` request.
 
         A request to resolve the incoming calls for a given `CallHierarchyItem`.
@@ -157,8 +59,8 @@ class LanguageClient(Client):
 
     def call_hierarchy_outgoing_calls(
         self,
-        params: CallHierarchyOutgoingCallsParams,
-        callback: Optional[Callable[[Optional[List[CallHierarchyOutgoingCall]]], None]] = None,
+        params: types.CallHierarchyOutgoingCallsParams,
+        callback: Optional[Callable[[Optional[List[types.CallHierarchyOutgoingCall]]], None]] = None,
     ) -> Future:
         """Make a ``callHierarchy/outgoingCalls`` request.
 
@@ -173,8 +75,8 @@ class LanguageClient(Client):
 
     async def call_hierarchy_outgoing_calls_async(
         self,
-        params: CallHierarchyOutgoingCallsParams,
-    ) -> Optional[List[CallHierarchyOutgoingCall]]:
+        params: types.CallHierarchyOutgoingCallsParams,
+    ) -> Optional[List[types.CallHierarchyOutgoingCall]]:
         """Make a ``callHierarchy/outgoingCalls`` request.
 
         A request to resolve the outgoing calls for a given `CallHierarchyItem`.
@@ -188,14 +90,14 @@ class LanguageClient(Client):
 
     def code_action_resolve(
         self,
-        params: CodeAction,
-        callback: Optional[Callable[[CodeAction], None]] = None,
+        params: types.CodeAction,
+        callback: Optional[Callable[[types.CodeAction], None]] = None,
     ) -> Future:
         """Make a ``codeAction/resolve`` request.
 
         Request to resolve additional information for a given code action.The request's
-        parameter is of type {@link CodeAction} the response is of type {@link CodeAction}
-        or a Thenable that resolves to such.
+        parameter is of type {@link CodeAction} the response
+        is of type {@link CodeAction} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -204,13 +106,13 @@ class LanguageClient(Client):
 
     async def code_action_resolve_async(
         self,
-        params: CodeAction,
-    ) -> CodeAction:
+        params: types.CodeAction,
+    ) -> types.CodeAction:
         """Make a ``codeAction/resolve`` request.
 
         Request to resolve additional information for a given code action.The request's
-        parameter is of type {@link CodeAction} the response is of type {@link CodeAction}
-        or a Thenable that resolves to such.
+        parameter is of type {@link CodeAction} the response
+        is of type {@link CodeAction} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -219,8 +121,8 @@ class LanguageClient(Client):
 
     def code_lens_resolve(
         self,
-        params: CodeLens,
-        callback: Optional[Callable[[CodeLens], None]] = None,
+        params: types.CodeLens,
+        callback: Optional[Callable[[types.CodeLens], None]] = None,
     ) -> Future:
         """Make a ``codeLens/resolve`` request.
 
@@ -233,8 +135,8 @@ class LanguageClient(Client):
 
     async def code_lens_resolve_async(
         self,
-        params: CodeLens,
-    ) -> CodeLens:
+        params: types.CodeLens,
+    ) -> types.CodeLens:
         """Make a ``codeLens/resolve`` request.
 
         A request to resolve a command for a given code lens.
@@ -246,14 +148,14 @@ class LanguageClient(Client):
 
     def completion_item_resolve(
         self,
-        params: CompletionItem,
-        callback: Optional[Callable[[CompletionItem], None]] = None,
+        params: types.CompletionItem,
+        callback: Optional[Callable[[types.CompletionItem], None]] = None,
     ) -> Future:
         """Make a ``completionItem/resolve`` request.
 
-        Request to resolve additional information for a given completion item.The
-        request's parameter is of type {@link CompletionItem} the response is of type {@link
-        CompletionItem} or a Thenable that resolves to such.
+        Request to resolve additional information for a given completion item.The request's
+        parameter is of type {@link CompletionItem} the response
+        is of type {@link CompletionItem} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -262,13 +164,13 @@ class LanguageClient(Client):
 
     async def completion_item_resolve_async(
         self,
-        params: CompletionItem,
-    ) -> CompletionItem:
+        params: types.CompletionItem,
+    ) -> types.CompletionItem:
         """Make a ``completionItem/resolve`` request.
 
-        Request to resolve additional information for a given completion item.The
-        request's parameter is of type {@link CompletionItem} the response is of type {@link
-        CompletionItem} or a Thenable that resolves to such.
+        Request to resolve additional information for a given completion item.The request's
+        parameter is of type {@link CompletionItem} the response
+        is of type {@link CompletionItem} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -277,15 +179,14 @@ class LanguageClient(Client):
 
     def document_link_resolve(
         self,
-        params: DocumentLink,
-        callback: Optional[Callable[[DocumentLink], None]] = None,
+        params: types.DocumentLink,
+        callback: Optional[Callable[[types.DocumentLink], None]] = None,
     ) -> Future:
         """Make a ``documentLink/resolve`` request.
 
-        Request to resolve additional information for a given document link.
-
-        The request's parameter is of type {@link DocumentLink} the response is of type
-        {@link DocumentLink} or a Thenable that resolves to such.
+        Request to resolve additional information for a given document link. The request's
+        parameter is of type {@link DocumentLink} the response
+        is of type {@link DocumentLink} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -294,14 +195,13 @@ class LanguageClient(Client):
 
     async def document_link_resolve_async(
         self,
-        params: DocumentLink,
-    ) -> DocumentLink:
+        params: types.DocumentLink,
+    ) -> types.DocumentLink:
         """Make a ``documentLink/resolve`` request.
 
-        Request to resolve additional information for a given document link.
-
-        The request's parameter is of type {@link DocumentLink} the response is of type
-        {@link DocumentLink} or a Thenable that resolves to such.
+        Request to resolve additional information for a given document link. The request's
+        parameter is of type {@link DocumentLink} the response
+        is of type {@link DocumentLink} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -310,16 +210,16 @@ class LanguageClient(Client):
 
     def initialize(
         self,
-        params: InitializeParams,
-        callback: Optional[Callable[[InitializeResult], None]] = None,
+        params: types.InitializeParams,
+        callback: Optional[Callable[[types.InitializeResult], None]] = None,
     ) -> Future:
         """Make a ``initialize`` request.
 
         The initialize request is sent from the client to the server.
-
-        It is sent once as the request after starting up the server. The requests parameter
-        is of type {@link InitializeParams} the response if of type {@link InitializeResult}
-        of a Thenable that resolves to such.
+        It is sent once as the request after starting up the server.
+        The requests parameter is of type {@link InitializeParams}
+        the response if of type {@link InitializeResult} of a Thenable that
+        resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -328,15 +228,15 @@ class LanguageClient(Client):
 
     async def initialize_async(
         self,
-        params: InitializeParams,
-    ) -> InitializeResult:
+        params: types.InitializeParams,
+    ) -> types.InitializeResult:
         """Make a ``initialize`` request.
 
         The initialize request is sent from the client to the server.
-
-        It is sent once as the request after starting up the server. The requests parameter
-        is of type {@link InitializeParams} the response if of type {@link InitializeResult}
-        of a Thenable that resolves to such.
+        It is sent once as the request after starting up the server.
+        The requests parameter is of type {@link InitializeParams}
+        the response if of type {@link InitializeResult} of a Thenable that
+        resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -345,14 +245,14 @@ class LanguageClient(Client):
 
     def inlay_hint_resolve(
         self,
-        params: InlayHint,
-        callback: Optional[Callable[[InlayHint], None]] = None,
+        params: types.InlayHint,
+        callback: Optional[Callable[[types.InlayHint], None]] = None,
     ) -> Future:
         """Make a ``inlayHint/resolve`` request.
 
-        A request to resolve additional properties for an inlay hint. The request's
-        parameter is of type {@link InlayHint}, the response is of type {@link InlayHint} or
-        a Thenable that resolves to such.
+        A request to resolve additional properties for an inlay hint.
+        The request's parameter is of type {@link InlayHint}, the response is
+        of type {@link InlayHint} or a Thenable that resolves to such.
 
         @since 3.17.0
         """
@@ -363,13 +263,13 @@ class LanguageClient(Client):
 
     async def inlay_hint_resolve_async(
         self,
-        params: InlayHint,
-    ) -> InlayHint:
+        params: types.InlayHint,
+    ) -> types.InlayHint:
         """Make a ``inlayHint/resolve`` request.
 
-        A request to resolve additional properties for an inlay hint. The request's
-        parameter is of type {@link InlayHint}, the response is of type {@link InlayHint} or
-        a Thenable that resolves to such.
+        A request to resolve additional properties for an inlay hint.
+        The request's parameter is of type {@link InlayHint}, the response is
+        of type {@link InlayHint} or a Thenable that resolves to such.
 
         @since 3.17.0
         """
@@ -386,9 +286,9 @@ class LanguageClient(Client):
         """Make a ``shutdown`` request.
 
         A shutdown request is sent from the client to the server.
-
-        It is sent once when the client decides to shutdown the server. The only
-        notification that is sent after a shutdown request is the exit event.
+        It is sent once when the client decides to shutdown the
+        server. The only notification that is sent after a shutdown request
+        is the exit event.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -402,9 +302,9 @@ class LanguageClient(Client):
         """Make a ``shutdown`` request.
 
         A shutdown request is sent from the client to the server.
-
-        It is sent once when the client decides to shutdown the server. The only
-        notification that is sent after a shutdown request is the exit event.
+        It is sent once when the client decides to shutdown the
+        server. The only notification that is sent after a shutdown request
+        is the exit event.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -413,8 +313,8 @@ class LanguageClient(Client):
 
     def text_document_code_action(
         self,
-        params: CodeActionParams,
-        callback: Optional[Callable[[Optional[List[Union[Command, CodeAction]]]], None]] = None,
+        params: types.CodeActionParams,
+        callback: Optional[Callable[[Optional[List[Union[types.Command, types.CodeAction]]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/codeAction`` request.
 
@@ -427,8 +327,8 @@ class LanguageClient(Client):
 
     async def text_document_code_action_async(
         self,
-        params: CodeActionParams,
-    ) -> Optional[List[Union[Command, CodeAction]]]:
+        params: types.CodeActionParams,
+    ) -> Optional[List[Union[types.Command, types.CodeAction]]]:
         """Make a ``textDocument/codeAction`` request.
 
         A request to provide commands for the given text document and range.
@@ -440,8 +340,8 @@ class LanguageClient(Client):
 
     def text_document_code_lens(
         self,
-        params: CodeLensParams,
-        callback: Optional[Callable[[Optional[List[CodeLens]]], None]] = None,
+        params: types.CodeLensParams,
+        callback: Optional[Callable[[Optional[List[types.CodeLens]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/codeLens`` request.
 
@@ -454,8 +354,8 @@ class LanguageClient(Client):
 
     async def text_document_code_lens_async(
         self,
-        params: CodeLensParams,
-    ) -> Optional[List[CodeLens]]:
+        params: types.CodeLensParams,
+    ) -> Optional[List[types.CodeLens]]:
         """Make a ``textDocument/codeLens`` request.
 
         A request to provide code lens for the given text document.
@@ -467,16 +367,15 @@ class LanguageClient(Client):
 
     def text_document_color_presentation(
         self,
-        params: ColorPresentationParams,
-        callback: Optional[Callable[[List[ColorPresentation]], None]] = None,
+        params: types.ColorPresentationParams,
+        callback: Optional[Callable[[List[types.ColorPresentation]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/colorPresentation`` request.
 
-        A request to list all presentation for a color.
-
-        The request's parameter is of type {@link ColorPresentationParams} the response is
-        of type {@link ColorInformation ColorInformation[]} or a Thenable that resolves to
-        such.
+        A request to list all presentation for a color. The request's
+        parameter is of type {@link ColorPresentationParams} the
+        response is of type {@link ColorInformation ColorInformation[]} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -485,15 +384,14 @@ class LanguageClient(Client):
 
     async def text_document_color_presentation_async(
         self,
-        params: ColorPresentationParams,
-    ) -> List[ColorPresentation]:
+        params: types.ColorPresentationParams,
+    ) -> List[types.ColorPresentation]:
         """Make a ``textDocument/colorPresentation`` request.
 
-        A request to list all presentation for a color.
-
-        The request's parameter is of type {@link ColorPresentationParams} the response is
-        of type {@link ColorInformation ColorInformation[]} or a Thenable that resolves to
-        such.
+        A request to list all presentation for a color. The request's
+        parameter is of type {@link ColorPresentationParams} the
+        response is of type {@link ColorInformation ColorInformation[]} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -502,21 +400,20 @@ class LanguageClient(Client):
 
     def text_document_completion(
         self,
-        params: CompletionParams,
-        callback: Optional[Callable[[Union[List[CompletionItem], CompletionList, None]], None]] = None,
+        params: types.CompletionParams,
+        callback: Optional[Callable[[Union[List[types.CompletionItem], types.CompletionList, None]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/completion`` request.
 
         Request to request completion at a given text document position. The request's
-        parameter is of type {@link TextDocumentPosition} the response is of type {@link
-        CompletionItem CompletionItem[]} or {@link CompletionList} or a Thenable that
-        resolves to such.
+        parameter is of type {@link TextDocumentPosition} the response
+        is of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}
+        or a Thenable that resolves to such.
 
         The request can delay the computation of the {@link CompletionItem.detail `detail`}
-        and {@link CompletionItem.documentation `documentation`} properties to the
-        `completionItem/resolve` request. However, properties that are needed for the
-        initial sorting and filtering, like `sortText`, `filterText`, `insertText`, and
-        `textEdit`, must not be changed during resolve.
+        and {@link CompletionItem.documentation `documentation`} properties to the `completionItem/resolve`
+        request. However, properties that are needed for the initial sorting and filtering, like `sortText`,
+        `filterText`, `insertText`, and `textEdit`, must not be changed during resolve.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -525,20 +422,19 @@ class LanguageClient(Client):
 
     async def text_document_completion_async(
         self,
-        params: CompletionParams,
-    ) -> Union[List[CompletionItem], CompletionList, None]:
+        params: types.CompletionParams,
+    ) -> Union[List[types.CompletionItem], types.CompletionList, None]:
         """Make a ``textDocument/completion`` request.
 
         Request to request completion at a given text document position. The request's
-        parameter is of type {@link TextDocumentPosition} the response is of type {@link
-        CompletionItem CompletionItem[]} or {@link CompletionList} or a Thenable that
-        resolves to such.
+        parameter is of type {@link TextDocumentPosition} the response
+        is of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}
+        or a Thenable that resolves to such.
 
         The request can delay the computation of the {@link CompletionItem.detail `detail`}
-        and {@link CompletionItem.documentation `documentation`} properties to the
-        `completionItem/resolve` request. However, properties that are needed for the
-        initial sorting and filtering, like `sortText`, `filterText`, `insertText`, and
-        `textEdit`, must not be changed during resolve.
+        and {@link CompletionItem.documentation `documentation`} properties to the `completionItem/resolve`
+        request. However, properties that are needed for the initial sorting and filtering, like `sortText`,
+        `filterText`, `insertText`, and `textEdit`, must not be changed during resolve.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -547,17 +443,15 @@ class LanguageClient(Client):
 
     def text_document_declaration(
         self,
-        params: DeclarationParams,
-        callback: Optional[Callable[[Union[Location, List[Location], List[LocationLink], None]], None]] = None,
+        params: types.DeclarationParams,
+        callback: Optional[Callable[[Union[types.Location, List[types.Location], List[types.LocationLink], None]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/declaration`` request.
 
         A request to resolve the type definition locations of a symbol at a given text
-        document position.
-
-        The request's parameter is of type [TextDocumentPositionParams]
-        (#TextDocumentPositionParams) the response is of type {@link Declaration} or a typed
-        array of {@link DeclarationLink} or a Thenable that resolves to such.
+        document position. The request's parameter is of type {@link TextDocumentPositionParams}
+        the response is of type {@link Declaration} or a typed array of {@link DeclarationLink}
+        or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -566,16 +460,14 @@ class LanguageClient(Client):
 
     async def text_document_declaration_async(
         self,
-        params: DeclarationParams,
-    ) -> Union[Location, List[Location], List[LocationLink], None]:
+        params: types.DeclarationParams,
+    ) -> Union[types.Location, List[types.Location], List[types.LocationLink], None]:
         """Make a ``textDocument/declaration`` request.
 
         A request to resolve the type definition locations of a symbol at a given text
-        document position.
-
-        The request's parameter is of type [TextDocumentPositionParams]
-        (#TextDocumentPositionParams) the response is of type {@link Declaration} or a typed
-        array of {@link DeclarationLink} or a Thenable that resolves to such.
+        document position. The request's parameter is of type {@link TextDocumentPositionParams}
+        the response is of type {@link Declaration} or a typed array of {@link DeclarationLink}
+        or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -584,17 +476,15 @@ class LanguageClient(Client):
 
     def text_document_definition(
         self,
-        params: DefinitionParams,
-        callback: Optional[Callable[[Union[Location, List[Location], List[LocationLink], None]], None]] = None,
+        params: types.DefinitionParams,
+        callback: Optional[Callable[[Union[types.Location, List[types.Location], List[types.LocationLink], None]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/definition`` request.
 
-        A request to resolve the definition location of a symbol at a given text document
-        position.
-
-        The request's parameter is of type [TextDocumentPosition] (#TextDocumentPosition)
-        the response is of either type {@link Definition} or a typed array of {@link
-        DefinitionLink} or a Thenable that resolves to such.
+        A request to resolve the definition location of a symbol at a given text
+        document position. The request's parameter is of type {@link TextDocumentPosition}
+        the response is of either type {@link Definition} or a typed array of
+        {@link DefinitionLink} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -603,16 +493,14 @@ class LanguageClient(Client):
 
     async def text_document_definition_async(
         self,
-        params: DefinitionParams,
-    ) -> Union[Location, List[Location], List[LocationLink], None]:
+        params: types.DefinitionParams,
+    ) -> Union[types.Location, List[types.Location], List[types.LocationLink], None]:
         """Make a ``textDocument/definition`` request.
 
-        A request to resolve the definition location of a symbol at a given text document
-        position.
-
-        The request's parameter is of type [TextDocumentPosition] (#TextDocumentPosition)
-        the response is of either type {@link Definition} or a typed array of {@link
-        DefinitionLink} or a Thenable that resolves to such.
+        A request to resolve the definition location of a symbol at a given text
+        document position. The request's parameter is of type {@link TextDocumentPosition}
+        the response is of either type {@link Definition} or a typed array of
+        {@link DefinitionLink} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -621,8 +509,8 @@ class LanguageClient(Client):
 
     def text_document_diagnostic(
         self,
-        params: DocumentDiagnosticParams,
-        callback: Optional[Callable[[Union[RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport]], None]] = None,
+        params: types.DocumentDiagnosticParams,
+        callback: Optional[Callable[[Union[types.RelatedFullDocumentDiagnosticReport, types.RelatedUnchangedDocumentDiagnosticReport]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/diagnostic`` request.
 
@@ -637,8 +525,8 @@ class LanguageClient(Client):
 
     async def text_document_diagnostic_async(
         self,
-        params: DocumentDiagnosticParams,
-    ) -> Union[RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport]:
+        params: types.DocumentDiagnosticParams,
+    ) -> Union[types.RelatedFullDocumentDiagnosticReport, types.RelatedUnchangedDocumentDiagnosticReport]:
         """Make a ``textDocument/diagnostic`` request.
 
         The document diagnostic request definition.
@@ -652,16 +540,15 @@ class LanguageClient(Client):
 
     def text_document_document_color(
         self,
-        params: DocumentColorParams,
-        callback: Optional[Callable[[List[ColorInformation]], None]] = None,
+        params: types.DocumentColorParams,
+        callback: Optional[Callable[[List[types.ColorInformation]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/documentColor`` request.
 
-        A request to list all color symbols found in a given text document.
-
-        The request's parameter is of type {@link DocumentColorParams} the response is of
-        type {@link ColorInformation ColorInformation[]} or a Thenable that resolves to
-        such.
+        A request to list all color symbols found in a given text document. The request's
+        parameter is of type {@link DocumentColorParams} the
+        response is of type {@link ColorInformation ColorInformation[]} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -670,15 +557,14 @@ class LanguageClient(Client):
 
     async def text_document_document_color_async(
         self,
-        params: DocumentColorParams,
-    ) -> List[ColorInformation]:
+        params: types.DocumentColorParams,
+    ) -> List[types.ColorInformation]:
         """Make a ``textDocument/documentColor`` request.
 
-        A request to list all color symbols found in a given text document.
-
-        The request's parameter is of type {@link DocumentColorParams} the response is of
-        type {@link ColorInformation ColorInformation[]} or a Thenable that resolves to
-        such.
+        A request to list all color symbols found in a given text document. The request's
+        parameter is of type {@link DocumentColorParams} the
+        response is of type {@link ColorInformation ColorInformation[]} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -687,17 +573,15 @@ class LanguageClient(Client):
 
     def text_document_document_highlight(
         self,
-        params: DocumentHighlightParams,
-        callback: Optional[Callable[[Optional[List[DocumentHighlight]]], None]] = None,
+        params: types.DocumentHighlightParams,
+        callback: Optional[Callable[[Optional[List[types.DocumentHighlight]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/documentHighlight`` request.
 
-        Request to resolve a {@link DocumentHighlight} for a given text document
-        position.
-
-        The request's parameter is of type [TextDocumentPosition] (#TextDocumentPosition)
-        the request response is of type [DocumentHighlight[]] (#DocumentHighlight) or a
-        Thenable that resolves to such.
+        Request to resolve a {@link DocumentHighlight} for a given
+        text document position. The request's parameter is of type {@link TextDocumentPosition}
+        the request response is an array of type {@link DocumentHighlight}
+        or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -706,16 +590,14 @@ class LanguageClient(Client):
 
     async def text_document_document_highlight_async(
         self,
-        params: DocumentHighlightParams,
-    ) -> Optional[List[DocumentHighlight]]:
+        params: types.DocumentHighlightParams,
+    ) -> Optional[List[types.DocumentHighlight]]:
         """Make a ``textDocument/documentHighlight`` request.
 
-        Request to resolve a {@link DocumentHighlight} for a given text document
-        position.
-
-        The request's parameter is of type [TextDocumentPosition] (#TextDocumentPosition)
-        the request response is of type [DocumentHighlight[]] (#DocumentHighlight) or a
-        Thenable that resolves to such.
+        Request to resolve a {@link DocumentHighlight} for a given
+        text document position. The request's parameter is of type {@link TextDocumentPosition}
+        the request response is an array of type {@link DocumentHighlight}
+        or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -724,12 +606,12 @@ class LanguageClient(Client):
 
     def text_document_document_link(
         self,
-        params: DocumentLinkParams,
-        callback: Optional[Callable[[Optional[List[DocumentLink]]], None]] = None,
+        params: types.DocumentLinkParams,
+        callback: Optional[Callable[[Optional[List[types.DocumentLink]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/documentLink`` request.
 
-        A request to provide document links.
+        A request to provide document links
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -738,11 +620,11 @@ class LanguageClient(Client):
 
     async def text_document_document_link_async(
         self,
-        params: DocumentLinkParams,
-    ) -> Optional[List[DocumentLink]]:
+        params: types.DocumentLinkParams,
+    ) -> Optional[List[types.DocumentLink]]:
         """Make a ``textDocument/documentLink`` request.
 
-        A request to provide document links.
+        A request to provide document links
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -751,16 +633,15 @@ class LanguageClient(Client):
 
     def text_document_document_symbol(
         self,
-        params: DocumentSymbolParams,
-        callback: Optional[Callable[[Union[List[SymbolInformation], List[DocumentSymbol], None]], None]] = None,
+        params: types.DocumentSymbolParams,
+        callback: Optional[Callable[[Union[List[types.SymbolInformation], List[types.DocumentSymbol], None]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/documentSymbol`` request.
 
-        A request to list all symbols found in a given text document.
-
-        The request's parameter is of type {@link TextDocumentIdentifier} the response is of
-        type {@link SymbolInformation SymbolInformation[]} or a Thenable that resolves to
-        such.
+        A request to list all symbols found in a given text document. The request's
+        parameter is of type {@link TextDocumentIdentifier} the
+        response is of type {@link SymbolInformation SymbolInformation[]} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -769,15 +650,14 @@ class LanguageClient(Client):
 
     async def text_document_document_symbol_async(
         self,
-        params: DocumentSymbolParams,
-    ) -> Union[List[SymbolInformation], List[DocumentSymbol], None]:
+        params: types.DocumentSymbolParams,
+    ) -> Union[List[types.SymbolInformation], List[types.DocumentSymbol], None]:
         """Make a ``textDocument/documentSymbol`` request.
 
-        A request to list all symbols found in a given text document.
-
-        The request's parameter is of type {@link TextDocumentIdentifier} the response is of
-        type {@link SymbolInformation SymbolInformation[]} or a Thenable that resolves to
-        such.
+        A request to list all symbols found in a given text document. The request's
+        parameter is of type {@link TextDocumentIdentifier} the
+        response is of type {@link SymbolInformation SymbolInformation[]} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -786,15 +666,15 @@ class LanguageClient(Client):
 
     def text_document_folding_range(
         self,
-        params: FoldingRangeParams,
-        callback: Optional[Callable[[Optional[List[FoldingRange]]], None]] = None,
+        params: types.FoldingRangeParams,
+        callback: Optional[Callable[[Optional[List[types.FoldingRange]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/foldingRange`` request.
 
-        A request to provide folding ranges in a document.
-
-        The request's parameter is of type {@link FoldingRangeParams}, the response is of
-        type {@link FoldingRangeList} or a Thenable that resolves to such.
+        A request to provide folding ranges in a document. The request's
+        parameter is of type {@link FoldingRangeParams}, the
+        response is of type {@link FoldingRangeList} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -803,14 +683,14 @@ class LanguageClient(Client):
 
     async def text_document_folding_range_async(
         self,
-        params: FoldingRangeParams,
-    ) -> Optional[List[FoldingRange]]:
+        params: types.FoldingRangeParams,
+    ) -> Optional[List[types.FoldingRange]]:
         """Make a ``textDocument/foldingRange`` request.
 
-        A request to provide folding ranges in a document.
-
-        The request's parameter is of type {@link FoldingRangeParams}, the response is of
-        type {@link FoldingRangeList} or a Thenable that resolves to such.
+        A request to provide folding ranges in a document. The request's
+        parameter is of type {@link FoldingRangeParams}, the
+        response is of type {@link FoldingRangeList} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -819,8 +699,8 @@ class LanguageClient(Client):
 
     def text_document_formatting(
         self,
-        params: DocumentFormattingParams,
-        callback: Optional[Callable[[Optional[List[TextEdit]]], None]] = None,
+        params: types.DocumentFormattingParams,
+        callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/formatting`` request.
 
@@ -833,8 +713,8 @@ class LanguageClient(Client):
 
     async def text_document_formatting_async(
         self,
-        params: DocumentFormattingParams,
-    ) -> Optional[List[TextEdit]]:
+        params: types.DocumentFormattingParams,
+    ) -> Optional[List[types.TextEdit]]:
         """Make a ``textDocument/formatting`` request.
 
         A request to format a whole document.
@@ -846,14 +726,13 @@ class LanguageClient(Client):
 
     def text_document_hover(
         self,
-        params: HoverParams,
-        callback: Optional[Callable[[Optional[Hover]], None]] = None,
+        params: types.HoverParams,
+        callback: Optional[Callable[[Optional[types.Hover]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/hover`` request.
 
-        Request to request hover information at a given text document position.
-
-        The request's parameter is of type {@link TextDocumentPosition} the response is of
+        Request to request hover information at a given text document position. The request's
+        parameter is of type {@link TextDocumentPosition} the response is of
         type {@link Hover} or a Thenable that resolves to such.
         """
         if self.stopped:
@@ -863,13 +742,12 @@ class LanguageClient(Client):
 
     async def text_document_hover_async(
         self,
-        params: HoverParams,
-    ) -> Optional[Hover]:
+        params: types.HoverParams,
+    ) -> Optional[types.Hover]:
         """Make a ``textDocument/hover`` request.
 
-        Request to request hover information at a given text document position.
-
-        The request's parameter is of type {@link TextDocumentPosition} the response is of
+        Request to request hover information at a given text document position. The request's
+        parameter is of type {@link TextDocumentPosition} the response is of
         type {@link Hover} or a Thenable that resolves to such.
         """
         if self.stopped:
@@ -879,17 +757,14 @@ class LanguageClient(Client):
 
     def text_document_implementation(
         self,
-        params: ImplementationParams,
-        callback: Optional[Callable[[Union[Location, List[Location], List[LocationLink], None]], None]] = None,
+        params: types.ImplementationParams,
+        callback: Optional[Callable[[Union[types.Location, List[types.Location], List[types.LocationLink], None]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/implementation`` request.
 
         A request to resolve the implementation locations of a symbol at a given text
-        document position.
-
-        The request's parameter is of type [TextDocumentPositionParams]
-        (#TextDocumentPositionParams) the response is of type {@link Definition} or a
-        Thenable that resolves to such.
+        document position. The request's parameter is of type {@link TextDocumentPositionParams}
+        the response is of type {@link Definition} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -898,16 +773,13 @@ class LanguageClient(Client):
 
     async def text_document_implementation_async(
         self,
-        params: ImplementationParams,
-    ) -> Union[Location, List[Location], List[LocationLink], None]:
+        params: types.ImplementationParams,
+    ) -> Union[types.Location, List[types.Location], List[types.LocationLink], None]:
         """Make a ``textDocument/implementation`` request.
 
         A request to resolve the implementation locations of a symbol at a given text
-        document position.
-
-        The request's parameter is of type [TextDocumentPositionParams]
-        (#TextDocumentPositionParams) the response is of type {@link Definition} or a
-        Thenable that resolves to such.
+        document position. The request's parameter is of type {@link TextDocumentPositionParams}
+        the response is of type {@link Definition} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -916,14 +788,14 @@ class LanguageClient(Client):
 
     def text_document_inlay_hint(
         self,
-        params: InlayHintParams,
-        callback: Optional[Callable[[Optional[List[InlayHint]]], None]] = None,
+        params: types.InlayHintParams,
+        callback: Optional[Callable[[Optional[List[types.InlayHint]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/inlayHint`` request.
 
         A request to provide inlay hints in a document. The request's parameter is of
-        type {@link InlayHintsParams}, the response is of type {@link InlayHint InlayHint[]}
-        or a Thenable that resolves to such.
+        type {@link InlayHintsParams}, the response is of type
+        {@link InlayHint InlayHint[]} or a Thenable that resolves to such.
 
         @since 3.17.0
         """
@@ -934,13 +806,13 @@ class LanguageClient(Client):
 
     async def text_document_inlay_hint_async(
         self,
-        params: InlayHintParams,
-    ) -> Optional[List[InlayHint]]:
+        params: types.InlayHintParams,
+    ) -> Optional[List[types.InlayHint]]:
         """Make a ``textDocument/inlayHint`` request.
 
         A request to provide inlay hints in a document. The request's parameter is of
-        type {@link InlayHintsParams}, the response is of type {@link InlayHint InlayHint[]}
-        or a Thenable that resolves to such.
+        type {@link InlayHintsParams}, the response is of type
+        {@link InlayHint InlayHint[]} or a Thenable that resolves to such.
 
         @since 3.17.0
         """
@@ -949,16 +821,53 @@ class LanguageClient(Client):
 
         return await self.protocol.send_request_async("textDocument/inlayHint", params)
 
+    def text_document_inline_completion(
+        self,
+        params: types.InlineCompletionParams,
+        callback: Optional[Callable[[Union[types.InlineCompletionList, List[types.InlineCompletionItem], None]], None]] = None,
+    ) -> Future:
+        """Make a ``textDocument/inlineCompletion`` request.
+
+        A request to provide inline completions in a document. The request's parameter is of
+        type {@link InlineCompletionParams}, the response is of type
+        {@link InlineCompletion InlineCompletion[]} or a Thenable that resolves to such.
+
+        @since 3.18.0
+        @proposed
+        """
+        if self.stopped:
+            raise RuntimeError("Client has been stopped.")
+
+        return self.protocol.send_request("textDocument/inlineCompletion", params, callback)
+
+    async def text_document_inline_completion_async(
+        self,
+        params: types.InlineCompletionParams,
+    ) -> Union[types.InlineCompletionList, List[types.InlineCompletionItem], None]:
+        """Make a ``textDocument/inlineCompletion`` request.
+
+        A request to provide inline completions in a document. The request's parameter is of
+        type {@link InlineCompletionParams}, the response is of type
+        {@link InlineCompletion InlineCompletion[]} or a Thenable that resolves to such.
+
+        @since 3.18.0
+        @proposed
+        """
+        if self.stopped:
+            raise RuntimeError("Client has been stopped.")
+
+        return await self.protocol.send_request_async("textDocument/inlineCompletion", params)
+
     def text_document_inline_value(
         self,
-        params: InlineValueParams,
-        callback: Optional[Callable[[Optional[List[Union[InlineValueText, InlineValueVariableLookup, InlineValueEvaluatableExpression]]]], None]] = None,
+        params: types.InlineValueParams,
+        callback: Optional[Callable[[Optional[List[Union[types.InlineValueText, types.InlineValueVariableLookup, types.InlineValueEvaluatableExpression]]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/inlineValue`` request.
 
         A request to provide inline values in a document. The request's parameter is of
-        type {@link InlineValueParams}, the response is of type {@link InlineValue
-        InlineValue[]} or a Thenable that resolves to such.
+        type {@link InlineValueParams}, the response is of type
+        {@link InlineValue InlineValue[]} or a Thenable that resolves to such.
 
         @since 3.17.0
         """
@@ -969,13 +878,13 @@ class LanguageClient(Client):
 
     async def text_document_inline_value_async(
         self,
-        params: InlineValueParams,
-    ) -> Optional[List[Union[InlineValueText, InlineValueVariableLookup, InlineValueEvaluatableExpression]]]:
+        params: types.InlineValueParams,
+    ) -> Optional[List[Union[types.InlineValueText, types.InlineValueVariableLookup, types.InlineValueEvaluatableExpression]]]:
         """Make a ``textDocument/inlineValue`` request.
 
         A request to provide inline values in a document. The request's parameter is of
-        type {@link InlineValueParams}, the response is of type {@link InlineValue
-        InlineValue[]} or a Thenable that resolves to such.
+        type {@link InlineValueParams}, the response is of type
+        {@link InlineValue InlineValue[]} or a Thenable that resolves to such.
 
         @since 3.17.0
         """
@@ -986,8 +895,8 @@ class LanguageClient(Client):
 
     def text_document_linked_editing_range(
         self,
-        params: LinkedEditingRangeParams,
-        callback: Optional[Callable[[Optional[LinkedEditingRanges]], None]] = None,
+        params: types.LinkedEditingRangeParams,
+        callback: Optional[Callable[[Optional[types.LinkedEditingRanges]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/linkedEditingRange`` request.
 
@@ -1002,8 +911,8 @@ class LanguageClient(Client):
 
     async def text_document_linked_editing_range_async(
         self,
-        params: LinkedEditingRangeParams,
-    ) -> Optional[LinkedEditingRanges]:
+        params: types.LinkedEditingRangeParams,
+    ) -> Optional[types.LinkedEditingRanges]:
         """Make a ``textDocument/linkedEditingRange`` request.
 
         A request to provide ranges that can be edited together.
@@ -1017,15 +926,14 @@ class LanguageClient(Client):
 
     def text_document_moniker(
         self,
-        params: MonikerParams,
-        callback: Optional[Callable[[Optional[List[Moniker]]], None]] = None,
+        params: types.MonikerParams,
+        callback: Optional[Callable[[Optional[List[types.Moniker]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/moniker`` request.
 
         A request to get the moniker of a symbol at a given text document position.
-
-        The request parameter is of type {@link TextDocumentPositionParams}. The response is
-        of type {@link Moniker Moniker[]} or `null`.
+        The request parameter is of type {@link TextDocumentPositionParams}.
+        The response is of type {@link Moniker Moniker[]} or `null`.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1034,14 +942,13 @@ class LanguageClient(Client):
 
     async def text_document_moniker_async(
         self,
-        params: MonikerParams,
-    ) -> Optional[List[Moniker]]:
+        params: types.MonikerParams,
+    ) -> Optional[List[types.Moniker]]:
         """Make a ``textDocument/moniker`` request.
 
         A request to get the moniker of a symbol at a given text document position.
-
-        The request parameter is of type {@link TextDocumentPositionParams}. The response is
-        of type {@link Moniker Moniker[]} or `null`.
+        The request parameter is of type {@link TextDocumentPositionParams}.
+        The response is of type {@link Moniker Moniker[]} or `null`.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1050,8 +957,8 @@ class LanguageClient(Client):
 
     def text_document_on_type_formatting(
         self,
-        params: DocumentOnTypeFormattingParams,
-        callback: Optional[Callable[[Optional[List[TextEdit]]], None]] = None,
+        params: types.DocumentOnTypeFormattingParams,
+        callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/onTypeFormatting`` request.
 
@@ -1064,8 +971,8 @@ class LanguageClient(Client):
 
     async def text_document_on_type_formatting_async(
         self,
-        params: DocumentOnTypeFormattingParams,
-    ) -> Optional[List[TextEdit]]:
+        params: types.DocumentOnTypeFormattingParams,
+    ) -> Optional[List[types.TextEdit]]:
         """Make a ``textDocument/onTypeFormatting`` request.
 
         A request to format a document on type.
@@ -1077,13 +984,13 @@ class LanguageClient(Client):
 
     def text_document_prepare_call_hierarchy(
         self,
-        params: CallHierarchyPrepareParams,
-        callback: Optional[Callable[[Optional[List[CallHierarchyItem]]], None]] = None,
+        params: types.CallHierarchyPrepareParams,
+        callback: Optional[Callable[[Optional[List[types.CallHierarchyItem]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/prepareCallHierarchy`` request.
 
-        A request to result a `CallHierarchyItem` in a document at a given position. Can
-        be used as an input to an incoming or outgoing call hierarchy.
+        A request to result a `CallHierarchyItem` in a document at a given position.
+        Can be used as an input to an incoming or outgoing call hierarchy.
 
         @since 3.16.0
         """
@@ -1094,12 +1001,12 @@ class LanguageClient(Client):
 
     async def text_document_prepare_call_hierarchy_async(
         self,
-        params: CallHierarchyPrepareParams,
-    ) -> Optional[List[CallHierarchyItem]]:
+        params: types.CallHierarchyPrepareParams,
+    ) -> Optional[List[types.CallHierarchyItem]]:
         """Make a ``textDocument/prepareCallHierarchy`` request.
 
-        A request to result a `CallHierarchyItem` in a document at a given position. Can
-        be used as an input to an incoming or outgoing call hierarchy.
+        A request to result a `CallHierarchyItem` in a document at a given position.
+        Can be used as an input to an incoming or outgoing call hierarchy.
 
         @since 3.16.0
         """
@@ -1110,8 +1017,8 @@ class LanguageClient(Client):
 
     def text_document_prepare_rename(
         self,
-        params: PrepareRenameParams,
-        callback: Optional[Callable[[Union[Range, PrepareRenameResult_Type1, PrepareRenameResult_Type2, None]], None]] = None,
+        params: types.PrepareRenameParams,
+        callback: Optional[Callable[[Union[types.Range, types.PrepareRenameResult_Type1, types.PrepareRenameResult_Type2, None]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/prepareRename`` request.
 
@@ -1126,8 +1033,8 @@ class LanguageClient(Client):
 
     async def text_document_prepare_rename_async(
         self,
-        params: PrepareRenameParams,
-    ) -> Union[Range, PrepareRenameResult_Type1, PrepareRenameResult_Type2, None]:
+        params: types.PrepareRenameParams,
+    ) -> Union[types.Range, types.PrepareRenameResult_Type1, types.PrepareRenameResult_Type2, None]:
         """Make a ``textDocument/prepareRename`` request.
 
         A request to test and perform the setup necessary for a rename.
@@ -1141,13 +1048,13 @@ class LanguageClient(Client):
 
     def text_document_prepare_type_hierarchy(
         self,
-        params: TypeHierarchyPrepareParams,
-        callback: Optional[Callable[[Optional[List[TypeHierarchyItem]]], None]] = None,
+        params: types.TypeHierarchyPrepareParams,
+        callback: Optional[Callable[[Optional[List[types.TypeHierarchyItem]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/prepareTypeHierarchy`` request.
 
-        A request to result a `TypeHierarchyItem` in a document at a given position. Can
-        be used as an input to a subtypes or supertypes type hierarchy.
+        A request to result a `TypeHierarchyItem` in a document at a given position.
+        Can be used as an input to a subtypes or supertypes type hierarchy.
 
         @since 3.17.0
         """
@@ -1158,12 +1065,12 @@ class LanguageClient(Client):
 
     async def text_document_prepare_type_hierarchy_async(
         self,
-        params: TypeHierarchyPrepareParams,
-    ) -> Optional[List[TypeHierarchyItem]]:
+        params: types.TypeHierarchyPrepareParams,
+    ) -> Optional[List[types.TypeHierarchyItem]]:
         """Make a ``textDocument/prepareTypeHierarchy`` request.
 
-        A request to result a `TypeHierarchyItem` in a document at a given position. Can
-        be used as an input to a subtypes or supertypes type hierarchy.
+        A request to result a `TypeHierarchyItem` in a document at a given position.
+        Can be used as an input to a subtypes or supertypes type hierarchy.
 
         @since 3.17.0
         """
@@ -1172,10 +1079,43 @@ class LanguageClient(Client):
 
         return await self.protocol.send_request_async("textDocument/prepareTypeHierarchy", params)
 
+    def text_document_ranges_formatting(
+        self,
+        params: types.DocumentRangesFormattingParams,
+        callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
+    ) -> Future:
+        """Make a ``textDocument/rangesFormatting`` request.
+
+        A request to format ranges in a document.
+
+        @since 3.18.0
+        @proposed
+        """
+        if self.stopped:
+            raise RuntimeError("Client has been stopped.")
+
+        return self.protocol.send_request("textDocument/rangesFormatting", params, callback)
+
+    async def text_document_ranges_formatting_async(
+        self,
+        params: types.DocumentRangesFormattingParams,
+    ) -> Optional[List[types.TextEdit]]:
+        """Make a ``textDocument/rangesFormatting`` request.
+
+        A request to format ranges in a document.
+
+        @since 3.18.0
+        @proposed
+        """
+        if self.stopped:
+            raise RuntimeError("Client has been stopped.")
+
+        return await self.protocol.send_request_async("textDocument/rangesFormatting", params)
+
     def text_document_range_formatting(
         self,
-        params: DocumentRangeFormattingParams,
-        callback: Optional[Callable[[Optional[List[TextEdit]]], None]] = None,
+        params: types.DocumentRangeFormattingParams,
+        callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/rangeFormatting`` request.
 
@@ -1188,8 +1128,8 @@ class LanguageClient(Client):
 
     async def text_document_range_formatting_async(
         self,
-        params: DocumentRangeFormattingParams,
-    ) -> Optional[List[TextEdit]]:
+        params: types.DocumentRangeFormattingParams,
+    ) -> Optional[List[types.TextEdit]]:
         """Make a ``textDocument/rangeFormatting`` request.
 
         A request to format a range in a document.
@@ -1201,15 +1141,14 @@ class LanguageClient(Client):
 
     def text_document_references(
         self,
-        params: ReferenceParams,
-        callback: Optional[Callable[[Optional[List[Location]]], None]] = None,
+        params: types.ReferenceParams,
+        callback: Optional[Callable[[Optional[List[types.Location]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/references`` request.
 
-        A request to resolve project-wide references for the symbol denoted by the given
-        text document position.
-
-        The request's parameter is of type {@link ReferenceParams} the response is of type
+        A request to resolve project-wide references for the symbol denoted
+        by the given text document position. The request's parameter is of
+        type {@link ReferenceParams} the response is of type
         {@link Location Location[]} or a Thenable that resolves to such.
         """
         if self.stopped:
@@ -1219,14 +1158,13 @@ class LanguageClient(Client):
 
     async def text_document_references_async(
         self,
-        params: ReferenceParams,
-    ) -> Optional[List[Location]]:
+        params: types.ReferenceParams,
+    ) -> Optional[List[types.Location]]:
         """Make a ``textDocument/references`` request.
 
-        A request to resolve project-wide references for the symbol denoted by the given
-        text document position.
-
-        The request's parameter is of type {@link ReferenceParams} the response is of type
+        A request to resolve project-wide references for the symbol denoted
+        by the given text document position. The request's parameter is of
+        type {@link ReferenceParams} the response is of type
         {@link Location Location[]} or a Thenable that resolves to such.
         """
         if self.stopped:
@@ -1236,8 +1174,8 @@ class LanguageClient(Client):
 
     def text_document_rename(
         self,
-        params: RenameParams,
-        callback: Optional[Callable[[Optional[WorkspaceEdit]], None]] = None,
+        params: types.RenameParams,
+        callback: Optional[Callable[[Optional[types.WorkspaceEdit]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/rename`` request.
 
@@ -1250,8 +1188,8 @@ class LanguageClient(Client):
 
     async def text_document_rename_async(
         self,
-        params: RenameParams,
-    ) -> Optional[WorkspaceEdit]:
+        params: types.RenameParams,
+    ) -> Optional[types.WorkspaceEdit]:
         """Make a ``textDocument/rename`` request.
 
         A request to rename a symbol.
@@ -1263,15 +1201,15 @@ class LanguageClient(Client):
 
     def text_document_selection_range(
         self,
-        params: SelectionRangeParams,
-        callback: Optional[Callable[[Optional[List[SelectionRange]]], None]] = None,
+        params: types.SelectionRangeParams,
+        callback: Optional[Callable[[Optional[List[types.SelectionRange]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/selectionRange`` request.
 
-        A request to provide selection ranges in a document.
-
-        The request's parameter is of type {@link SelectionRangeParams}, the response is of
-        type {@link SelectionRange SelectionRange[]} or a Thenable that resolves to such.
+        A request to provide selection ranges in a document. The request's
+        parameter is of type {@link SelectionRangeParams}, the
+        response is of type {@link SelectionRange SelectionRange[]} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1280,14 +1218,14 @@ class LanguageClient(Client):
 
     async def text_document_selection_range_async(
         self,
-        params: SelectionRangeParams,
-    ) -> Optional[List[SelectionRange]]:
+        params: types.SelectionRangeParams,
+    ) -> Optional[List[types.SelectionRange]]:
         """Make a ``textDocument/selectionRange`` request.
 
-        A request to provide selection ranges in a document.
-
-        The request's parameter is of type {@link SelectionRangeParams}, the response is of
-        type {@link SelectionRange SelectionRange[]} or a Thenable that resolves to such.
+        A request to provide selection ranges in a document. The request's
+        parameter is of type {@link SelectionRangeParams}, the
+        response is of type {@link SelectionRange SelectionRange[]} or a Thenable
+        that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1296,8 +1234,8 @@ class LanguageClient(Client):
 
     def text_document_semantic_tokens_full(
         self,
-        params: SemanticTokensParams,
-        callback: Optional[Callable[[Optional[SemanticTokens]], None]] = None,
+        params: types.SemanticTokensParams,
+        callback: Optional[Callable[[Optional[types.SemanticTokens]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/semanticTokens/full`` request.
 
@@ -1310,8 +1248,8 @@ class LanguageClient(Client):
 
     async def text_document_semantic_tokens_full_async(
         self,
-        params: SemanticTokensParams,
-    ) -> Optional[SemanticTokens]:
+        params: types.SemanticTokensParams,
+    ) -> Optional[types.SemanticTokens]:
         """Make a ``textDocument/semanticTokens/full`` request.
 
         @since 3.16.0
@@ -1323,8 +1261,8 @@ class LanguageClient(Client):
 
     def text_document_semantic_tokens_full_delta(
         self,
-        params: SemanticTokensDeltaParams,
-        callback: Optional[Callable[[Union[SemanticTokens, SemanticTokensDelta, None]], None]] = None,
+        params: types.SemanticTokensDeltaParams,
+        callback: Optional[Callable[[Union[types.SemanticTokens, types.SemanticTokensDelta, None]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/semanticTokens/full/delta`` request.
 
@@ -1337,8 +1275,8 @@ class LanguageClient(Client):
 
     async def text_document_semantic_tokens_full_delta_async(
         self,
-        params: SemanticTokensDeltaParams,
-    ) -> Union[SemanticTokens, SemanticTokensDelta, None]:
+        params: types.SemanticTokensDeltaParams,
+    ) -> Union[types.SemanticTokens, types.SemanticTokensDelta, None]:
         """Make a ``textDocument/semanticTokens/full/delta`` request.
 
         @since 3.16.0
@@ -1350,8 +1288,8 @@ class LanguageClient(Client):
 
     def text_document_semantic_tokens_range(
         self,
-        params: SemanticTokensRangeParams,
-        callback: Optional[Callable[[Optional[SemanticTokens]], None]] = None,
+        params: types.SemanticTokensRangeParams,
+        callback: Optional[Callable[[Optional[types.SemanticTokens]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/semanticTokens/range`` request.
 
@@ -1364,8 +1302,8 @@ class LanguageClient(Client):
 
     async def text_document_semantic_tokens_range_async(
         self,
-        params: SemanticTokensRangeParams,
-    ) -> Optional[SemanticTokens]:
+        params: types.SemanticTokensRangeParams,
+    ) -> Optional[types.SemanticTokens]:
         """Make a ``textDocument/semanticTokens/range`` request.
 
         @since 3.16.0
@@ -1377,8 +1315,8 @@ class LanguageClient(Client):
 
     def text_document_signature_help(
         self,
-        params: SignatureHelpParams,
-        callback: Optional[Callable[[Optional[SignatureHelp]], None]] = None,
+        params: types.SignatureHelpParams,
+        callback: Optional[Callable[[Optional[types.SignatureHelp]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/signatureHelp`` request.
 
@@ -1391,8 +1329,8 @@ class LanguageClient(Client):
 
     async def text_document_signature_help_async(
         self,
-        params: SignatureHelpParams,
-    ) -> Optional[SignatureHelp]:
+        params: types.SignatureHelpParams,
+    ) -> Optional[types.SignatureHelp]:
         """Make a ``textDocument/signatureHelp`` request.
 
 
@@ -1404,17 +1342,14 @@ class LanguageClient(Client):
 
     def text_document_type_definition(
         self,
-        params: TypeDefinitionParams,
-        callback: Optional[Callable[[Union[Location, List[Location], List[LocationLink], None]], None]] = None,
+        params: types.TypeDefinitionParams,
+        callback: Optional[Callable[[Union[types.Location, List[types.Location], List[types.LocationLink], None]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/typeDefinition`` request.
 
         A request to resolve the type definition locations of a symbol at a given text
-        document position.
-
-        The request's parameter is of type [TextDocumentPositionParams]
-        (#TextDocumentPositionParams) the response is of type {@link Definition} or a
-        Thenable that resolves to such.
+        document position. The request's parameter is of type {@link TextDocumentPositionParams}
+        the response is of type {@link Definition} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1423,16 +1358,13 @@ class LanguageClient(Client):
 
     async def text_document_type_definition_async(
         self,
-        params: TypeDefinitionParams,
-    ) -> Union[Location, List[Location], List[LocationLink], None]:
+        params: types.TypeDefinitionParams,
+    ) -> Union[types.Location, List[types.Location], List[types.LocationLink], None]:
         """Make a ``textDocument/typeDefinition`` request.
 
         A request to resolve the type definition locations of a symbol at a given text
-        document position.
-
-        The request's parameter is of type [TextDocumentPositionParams]
-        (#TextDocumentPositionParams) the response is of type {@link Definition} or a
-        Thenable that resolves to such.
+        document position. The request's parameter is of type {@link TextDocumentPositionParams}
+        the response is of type {@link Definition} or a Thenable that resolves to such.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1441,18 +1373,17 @@ class LanguageClient(Client):
 
     def text_document_will_save_wait_until(
         self,
-        params: WillSaveTextDocumentParams,
-        callback: Optional[Callable[[Optional[List[TextEdit]]], None]] = None,
+        params: types.WillSaveTextDocumentParams,
+        callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
         """Make a ``textDocument/willSaveWaitUntil`` request.
 
-        A document will save request is sent from the client to the server before the
-        document is actually saved.
-
-        The request can return an array of TextEdits which will be applied to the text
-        document before it is saved. Please note that clients might drop results if
-        computing the text edits took too long or if a server constantly fails on this
-        request. This is done to keep the save fast and reliable.
+        A document will save request is sent from the client to the server before
+        the document is actually saved. The request can return an array of TextEdits
+        which will be applied to the text document before it is saved. Please note that
+        clients might drop results if computing the text edits took too long or if a
+        server constantly fails on this request. This is done to keep the save fast and
+        reliable.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1461,17 +1392,16 @@ class LanguageClient(Client):
 
     async def text_document_will_save_wait_until_async(
         self,
-        params: WillSaveTextDocumentParams,
-    ) -> Optional[List[TextEdit]]:
+        params: types.WillSaveTextDocumentParams,
+    ) -> Optional[List[types.TextEdit]]:
         """Make a ``textDocument/willSaveWaitUntil`` request.
 
-        A document will save request is sent from the client to the server before the
-        document is actually saved.
-
-        The request can return an array of TextEdits which will be applied to the text
-        document before it is saved. Please note that clients might drop results if
-        computing the text edits took too long or if a server constantly fails on this
-        request. This is done to keep the save fast and reliable.
+        A document will save request is sent from the client to the server before
+        the document is actually saved. The request can return an array of TextEdits
+        which will be applied to the text document before it is saved. Please note that
+        clients might drop results if computing the text edits took too long or if a
+        server constantly fails on this request. This is done to keep the save fast and
+        reliable.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1480,8 +1410,8 @@ class LanguageClient(Client):
 
     def type_hierarchy_subtypes(
         self,
-        params: TypeHierarchySubtypesParams,
-        callback: Optional[Callable[[Optional[List[TypeHierarchyItem]]], None]] = None,
+        params: types.TypeHierarchySubtypesParams,
+        callback: Optional[Callable[[Optional[List[types.TypeHierarchyItem]]], None]] = None,
     ) -> Future:
         """Make a ``typeHierarchy/subtypes`` request.
 
@@ -1496,8 +1426,8 @@ class LanguageClient(Client):
 
     async def type_hierarchy_subtypes_async(
         self,
-        params: TypeHierarchySubtypesParams,
-    ) -> Optional[List[TypeHierarchyItem]]:
+        params: types.TypeHierarchySubtypesParams,
+    ) -> Optional[List[types.TypeHierarchyItem]]:
         """Make a ``typeHierarchy/subtypes`` request.
 
         A request to resolve the subtypes for a given `TypeHierarchyItem`.
@@ -1511,8 +1441,8 @@ class LanguageClient(Client):
 
     def type_hierarchy_supertypes(
         self,
-        params: TypeHierarchySupertypesParams,
-        callback: Optional[Callable[[Optional[List[TypeHierarchyItem]]], None]] = None,
+        params: types.TypeHierarchySupertypesParams,
+        callback: Optional[Callable[[Optional[List[types.TypeHierarchyItem]]], None]] = None,
     ) -> Future:
         """Make a ``typeHierarchy/supertypes`` request.
 
@@ -1527,8 +1457,8 @@ class LanguageClient(Client):
 
     async def type_hierarchy_supertypes_async(
         self,
-        params: TypeHierarchySupertypesParams,
-    ) -> Optional[List[TypeHierarchyItem]]:
+        params: types.TypeHierarchySupertypesParams,
+    ) -> Optional[List[types.TypeHierarchyItem]]:
         """Make a ``typeHierarchy/supertypes`` request.
 
         A request to resolve the supertypes for a given `TypeHierarchyItem`.
@@ -1542,8 +1472,8 @@ class LanguageClient(Client):
 
     def workspace_diagnostic(
         self,
-        params: WorkspaceDiagnosticParams,
-        callback: Optional[Callable[[WorkspaceDiagnosticReport], None]] = None,
+        params: types.WorkspaceDiagnosticParams,
+        callback: Optional[Callable[[types.WorkspaceDiagnosticReport], None]] = None,
     ) -> Future:
         """Make a ``workspace/diagnostic`` request.
 
@@ -1558,8 +1488,8 @@ class LanguageClient(Client):
 
     async def workspace_diagnostic_async(
         self,
-        params: WorkspaceDiagnosticParams,
-    ) -> WorkspaceDiagnosticReport:
+        params: types.WorkspaceDiagnosticParams,
+    ) -> types.WorkspaceDiagnosticReport:
         """Make a ``workspace/diagnostic`` request.
 
         The workspace diagnostic request definition.
@@ -1573,15 +1503,13 @@ class LanguageClient(Client):
 
     def workspace_execute_command(
         self,
-        params: ExecuteCommandParams,
+        params: types.ExecuteCommandParams,
         callback: Optional[Callable[[Optional[Any]], None]] = None,
     ) -> Future:
         """Make a ``workspace/executeCommand`` request.
 
-        A request send from the client to the server to execute a command.
-
-        The request might return a workspace edit which the client will apply to the
-        workspace.
+        A request send from the client to the server to execute a command. The request might return
+        a workspace edit which the client will apply to the workspace.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1590,14 +1518,12 @@ class LanguageClient(Client):
 
     async def workspace_execute_command_async(
         self,
-        params: ExecuteCommandParams,
+        params: types.ExecuteCommandParams,
     ) -> Optional[Any]:
         """Make a ``workspace/executeCommand`` request.
 
-        A request send from the client to the server to execute a command.
-
-        The request might return a workspace edit which the client will apply to the
-        workspace.
+        A request send from the client to the server to execute a command. The request might return
+        a workspace edit which the client will apply to the workspace.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
@@ -1606,14 +1532,15 @@ class LanguageClient(Client):
 
     def workspace_symbol(
         self,
-        params: WorkspaceSymbolParams,
-        callback: Optional[Callable[[Union[List[SymbolInformation], List[WorkspaceSymbol], None]], None]] = None,
+        params: types.WorkspaceSymbolParams,
+        callback: Optional[Callable[[Union[List[types.SymbolInformation], List[types.WorkspaceSymbol], None]], None]] = None,
     ) -> Future:
         """Make a ``workspace/symbol`` request.
 
-        A request to list project-wide symbols matching the query string given by the
-        {@link WorkspaceSymbolParams}. The response is of type {@link SymbolInformation
-        SymbolInformation[]} or a Thenable that resolves to such.
+        A request to list project-wide symbols matching the query string given
+        by the {@link WorkspaceSymbolParams}. The response is
+        of type {@link SymbolInformation SymbolInformation[]} or a Thenable that
+        resolves to such.
 
         @since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients
          need to advertise support for WorkspaceSymbols via the client capability
@@ -1626,13 +1553,14 @@ class LanguageClient(Client):
 
     async def workspace_symbol_async(
         self,
-        params: WorkspaceSymbolParams,
-    ) -> Union[List[SymbolInformation], List[WorkspaceSymbol], None]:
+        params: types.WorkspaceSymbolParams,
+    ) -> Union[List[types.SymbolInformation], List[types.WorkspaceSymbol], None]:
         """Make a ``workspace/symbol`` request.
 
-        A request to list project-wide symbols matching the query string given by the
-        {@link WorkspaceSymbolParams}. The response is of type {@link SymbolInformation
-        SymbolInformation[]} or a Thenable that resolves to such.
+        A request to list project-wide symbols matching the query string given
+        by the {@link WorkspaceSymbolParams}. The response is
+        of type {@link SymbolInformation SymbolInformation[]} or a Thenable that
+        resolves to such.
 
         @since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients
          need to advertise support for WorkspaceSymbols via the client capability
@@ -1645,12 +1573,13 @@ class LanguageClient(Client):
 
     def workspace_symbol_resolve(
         self,
-        params: WorkspaceSymbol,
-        callback: Optional[Callable[[WorkspaceSymbol], None]] = None,
+        params: types.WorkspaceSymbol,
+        callback: Optional[Callable[[types.WorkspaceSymbol], None]] = None,
     ) -> Future:
         """Make a ``workspaceSymbol/resolve`` request.
 
-        A request to resolve the range inside the workspace symbol's location.
+        A request to resolve the range inside the workspace
+        symbol's location.
 
         @since 3.17.0
         """
@@ -1661,11 +1590,12 @@ class LanguageClient(Client):
 
     async def workspace_symbol_resolve_async(
         self,
-        params: WorkspaceSymbol,
-    ) -> WorkspaceSymbol:
+        params: types.WorkspaceSymbol,
+    ) -> types.WorkspaceSymbol:
         """Make a ``workspaceSymbol/resolve`` request.
 
-        A request to resolve the range inside the workspace symbol's location.
+        A request to resolve the range inside the workspace
+        symbol's location.
 
         @since 3.17.0
         """
@@ -1676,13 +1606,13 @@ class LanguageClient(Client):
 
     def workspace_will_create_files(
         self,
-        params: CreateFilesParams,
-        callback: Optional[Callable[[Optional[WorkspaceEdit]], None]] = None,
+        params: types.CreateFilesParams,
+        callback: Optional[Callable[[Optional[types.WorkspaceEdit]], None]] = None,
     ) -> Future:
         """Make a ``workspace/willCreateFiles`` request.
 
-        The will create files request is sent from the client to the server before files
-        are actually created as long as the creation is triggered from within the client.
+        The will create files request is sent from the client to the server before files are actually
+        created as long as the creation is triggered from within the client.
 
         The request can return a `WorkspaceEdit` which will be applied to workspace before the
         files are created. Hence the `WorkspaceEdit` can not manipulate the content of the file
@@ -1697,12 +1627,12 @@ class LanguageClient(Client):
 
     async def workspace_will_create_files_async(
         self,
-        params: CreateFilesParams,
-    ) -> Optional[WorkspaceEdit]:
+        params: types.CreateFilesParams,
+    ) -> Optional[types.WorkspaceEdit]:
         """Make a ``workspace/willCreateFiles`` request.
 
-        The will create files request is sent from the client to the server before files
-        are actually created as long as the creation is triggered from within the client.
+        The will create files request is sent from the client to the server before files are actually
+        created as long as the creation is triggered from within the client.
 
         The request can return a `WorkspaceEdit` which will be applied to workspace before the
         files are created. Hence the `WorkspaceEdit` can not manipulate the content of the file
@@ -1717,8 +1647,8 @@ class LanguageClient(Client):
 
     def workspace_will_delete_files(
         self,
-        params: DeleteFilesParams,
-        callback: Optional[Callable[[Optional[WorkspaceEdit]], None]] = None,
+        params: types.DeleteFilesParams,
+        callback: Optional[Callable[[Optional[types.WorkspaceEdit]], None]] = None,
     ) -> Future:
         """Make a ``workspace/willDeleteFiles`` request.
 
@@ -1734,8 +1664,8 @@ class LanguageClient(Client):
 
     async def workspace_will_delete_files_async(
         self,
-        params: DeleteFilesParams,
-    ) -> Optional[WorkspaceEdit]:
+        params: types.DeleteFilesParams,
+    ) -> Optional[types.WorkspaceEdit]:
         """Make a ``workspace/willDeleteFiles`` request.
 
         The did delete files notification is sent from the client to the server when
@@ -1750,13 +1680,13 @@ class LanguageClient(Client):
 
     def workspace_will_rename_files(
         self,
-        params: RenameFilesParams,
-        callback: Optional[Callable[[Optional[WorkspaceEdit]], None]] = None,
+        params: types.RenameFilesParams,
+        callback: Optional[Callable[[Optional[types.WorkspaceEdit]], None]] = None,
     ) -> Future:
         """Make a ``workspace/willRenameFiles`` request.
 
-        The will rename files request is sent from the client to the server before files
-        are actually renamed as long as the rename is triggered from within the client.
+        The will rename files request is sent from the client to the server before files are actually
+        renamed as long as the rename is triggered from within the client.
 
         @since 3.16.0
         """
@@ -1767,12 +1697,12 @@ class LanguageClient(Client):
 
     async def workspace_will_rename_files_async(
         self,
-        params: RenameFilesParams,
-    ) -> Optional[WorkspaceEdit]:
+        params: types.RenameFilesParams,
+    ) -> Optional[types.WorkspaceEdit]:
         """Make a ``workspace/willRenameFiles`` request.
 
-        The will rename files request is sent from the client to the server before files
-        are actually renamed as long as the rename is triggered from within the client.
+        The will rename files request is sent from the client to the server before files are actually
+        renamed as long as the rename is triggered from within the client.
 
         @since 3.16.0
         """
@@ -1781,7 +1711,7 @@ class LanguageClient(Client):
 
         return await self.protocol.send_request_async("workspace/willRenameFiles", params)
 
-    def cancel_request(self, params: CancelParams) -> None:
+    def cancel_request(self, params: types.CancelParams) -> None:
         """Send a ``$/cancelRequest`` notification.
 
 
@@ -1794,27 +1724,27 @@ class LanguageClient(Client):
     def exit(self, params: None) -> None:
         """Send a ``exit`` notification.
 
-        The exit event is sent from the client to the server to ask the server to exit
-        its process.
+        The exit event is sent from the client to the server to
+        ask the server to exit its process.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("exit", params)
 
-    def initialized(self, params: InitializedParams) -> None:
+    def initialized(self, params: types.InitializedParams) -> None:
         """Send a ``initialized`` notification.
 
-        The initialized notification is sent from the client to the server after the
-        client is fully initialized and the server is allowed to send requests from the
-        server to the client.
+        The initialized notification is sent from the client to the
+        server after the client is fully initialized and the server
+        is allowed to send requests from the server to the client.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("initialized", params)
 
-    def notebook_document_did_change(self, params: DidChangeNotebookDocumentParams) -> None:
+    def notebook_document_did_change(self, params: types.DidChangeNotebookDocumentParams) -> None:
         """Send a ``notebookDocument/didChange`` notification.
 
 
@@ -1824,7 +1754,7 @@ class LanguageClient(Client):
 
         self.protocol.notify("notebookDocument/didChange", params)
 
-    def notebook_document_did_close(self, params: DidCloseNotebookDocumentParams) -> None:
+    def notebook_document_did_close(self, params: types.DidCloseNotebookDocumentParams) -> None:
         """Send a ``notebookDocument/didClose`` notification.
 
         A notification sent when a notebook closes.
@@ -1836,7 +1766,7 @@ class LanguageClient(Client):
 
         self.protocol.notify("notebookDocument/didClose", params)
 
-    def notebook_document_did_open(self, params: DidOpenNotebookDocumentParams) -> None:
+    def notebook_document_did_open(self, params: types.DidOpenNotebookDocumentParams) -> None:
         """Send a ``notebookDocument/didOpen`` notification.
 
         A notification sent when a notebook opens.
@@ -1848,7 +1778,7 @@ class LanguageClient(Client):
 
         self.protocol.notify("notebookDocument/didOpen", params)
 
-    def notebook_document_did_save(self, params: DidSaveNotebookDocumentParams) -> None:
+    def notebook_document_did_save(self, params: types.DidSaveNotebookDocumentParams) -> None:
         """Send a ``notebookDocument/didSave`` notification.
 
         A notification sent when a notebook document is saved.
@@ -1860,7 +1790,7 @@ class LanguageClient(Client):
 
         self.protocol.notify("notebookDocument/didSave", params)
 
-    def progress(self, params: ProgressParams) -> None:
+    def progress(self, params: types.ProgressParams) -> None:
         """Send a ``$/progress`` notification.
 
 
@@ -1870,7 +1800,7 @@ class LanguageClient(Client):
 
         self.protocol.notify("$/progress", params)
 
-    def set_trace(self, params: SetTraceParams) -> None:
+    def set_trace(self, params: types.SetTraceParams) -> None:
         """Send a ``$/setTrace`` notification.
 
 
@@ -1880,7 +1810,7 @@ class LanguageClient(Client):
 
         self.protocol.notify("$/setTrace", params)
 
-    def text_document_did_change(self, params: DidChangeTextDocumentParams) -> None:
+    def text_document_did_change(self, params: types.DidChangeTextDocumentParams) -> None:
         """Send a ``textDocument/didChange`` notification.
 
         The document change notification is sent from the client to the server to signal
@@ -1891,53 +1821,51 @@ class LanguageClient(Client):
 
         self.protocol.notify("textDocument/didChange", params)
 
-    def text_document_did_close(self, params: DidCloseTextDocumentParams) -> None:
+    def text_document_did_close(self, params: types.DidCloseTextDocumentParams) -> None:
         """Send a ``textDocument/didClose`` notification.
 
-        The document close notification is sent from the client to the server when the
-        document got closed in the client.
-
-        The document's truth now exists where the document's uri points to (e.g. if the
-        document's uri is a file uri the truth now exists on disk). As with the open
-        notification the close notification is about managing the document's content.
-        Receiving a close notification doesn't mean that the document was open in an editor
-        before. A close notification requires a previous open notification to be sent.
+        The document close notification is sent from the client to the server when
+        the document got closed in the client. The document's truth now exists where
+        the document's uri points to (e.g. if the document's uri is a file uri the
+        truth now exists on disk). As with the open notification the close notification
+        is about managing the document's content. Receiving a close notification
+        doesn't mean that the document was open in an editor before. A close
+        notification requires a previous open notification to be sent.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("textDocument/didClose", params)
 
-    def text_document_did_open(self, params: DidOpenTextDocumentParams) -> None:
+    def text_document_did_open(self, params: types.DidOpenTextDocumentParams) -> None:
         """Send a ``textDocument/didOpen`` notification.
 
         The document open notification is sent from the client to the server to signal
-        newly opened text documents.
-
-        The document's truth is now managed by the client and the server must not try to
-        read the document's truth using the document's uri. Open in this sense means it is
-        managed by the client. It doesn't necessarily mean that its content is presented in
-        an editor. An open notification must not be sent more than once without a
-        corresponding close notification send before. This means open and close notification
-        must be balanced and the max open count is one.
+        newly opened text documents. The document's truth is now managed by the client
+        and the server must not try to read the document's truth using the document's
+        uri. Open in this sense means it is managed by the client. It doesn't necessarily
+        mean that its content is presented in an editor. An open notification must not
+        be sent more than once without a corresponding close notification send before.
+        This means open and close notification must be balanced and the max open count
+        is one.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("textDocument/didOpen", params)
 
-    def text_document_did_save(self, params: DidSaveTextDocumentParams) -> None:
+    def text_document_did_save(self, params: types.DidSaveTextDocumentParams) -> None:
         """Send a ``textDocument/didSave`` notification.
 
-        The document save notification is sent from the client to the server when the
-        document got saved in the client.
+        The document save notification is sent from the client to the server when
+        the document got saved in the client.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("textDocument/didSave", params)
 
-    def text_document_will_save(self, params: WillSaveTextDocumentParams) -> None:
+    def text_document_will_save(self, params: types.WillSaveTextDocumentParams) -> None:
         """Send a ``textDocument/willSave`` notification.
 
         A document will save notification is sent from the client to the server before
@@ -1948,54 +1876,52 @@ class LanguageClient(Client):
 
         self.protocol.notify("textDocument/willSave", params)
 
-    def window_work_done_progress_cancel(self, params: WorkDoneProgressCancelParams) -> None:
+    def window_work_done_progress_cancel(self, params: types.WorkDoneProgressCancelParams) -> None:
         """Send a ``window/workDoneProgress/cancel`` notification.
 
-        The `window/workDoneProgress/cancel` notification is sent from  the client to the
-        server to cancel a progress initiated on the server side.
+        The `window/workDoneProgress/cancel` notification is sent from  the client to the server to cancel a progress
+        initiated on the server side.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("window/workDoneProgress/cancel", params)
 
-    def workspace_did_change_configuration(self, params: DidChangeConfigurationParams) -> None:
+    def workspace_did_change_configuration(self, params: types.DidChangeConfigurationParams) -> None:
         """Send a ``workspace/didChangeConfiguration`` notification.
 
-        The configuration change notification is sent from the client to the server when
-        the client's configuration has changed.
-
-        The notification contains the changed configuration as defined by the language
-        client.
+        The configuration change notification is sent from the client to the server
+        when the client's configuration has changed. The notification contains
+        the changed configuration as defined by the language client.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("workspace/didChangeConfiguration", params)
 
-    def workspace_did_change_watched_files(self, params: DidChangeWatchedFilesParams) -> None:
+    def workspace_did_change_watched_files(self, params: types.DidChangeWatchedFilesParams) -> None:
         """Send a ``workspace/didChangeWatchedFiles`` notification.
 
-        The watched files notification is sent from the client to the server when the
-        client detects changes to file watched by the language client.
+        The watched files notification is sent from the client to the server when
+        the client detects changes to file watched by the language client.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("workspace/didChangeWatchedFiles", params)
 
-    def workspace_did_change_workspace_folders(self, params: DidChangeWorkspaceFoldersParams) -> None:
+    def workspace_did_change_workspace_folders(self, params: types.DidChangeWorkspaceFoldersParams) -> None:
         """Send a ``workspace/didChangeWorkspaceFolders`` notification.
 
-        The `workspace/didChangeWorkspaceFolders` notification is sent from the client to
-        the server when the workspace folder configuration changes.
+        The `workspace/didChangeWorkspaceFolders` notification is sent from the client to the server when the workspace
+        folder configuration changes.
         """
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
 
         self.protocol.notify("workspace/didChangeWorkspaceFolders", params)
 
-    def workspace_did_create_files(self, params: CreateFilesParams) -> None:
+    def workspace_did_create_files(self, params: types.CreateFilesParams) -> None:
         """Send a ``workspace/didCreateFiles`` notification.
 
         The did create files notification is sent from the client to the server when
@@ -2008,11 +1934,11 @@ class LanguageClient(Client):
 
         self.protocol.notify("workspace/didCreateFiles", params)
 
-    def workspace_did_delete_files(self, params: DeleteFilesParams) -> None:
+    def workspace_did_delete_files(self, params: types.DeleteFilesParams) -> None:
         """Send a ``workspace/didDeleteFiles`` notification.
 
-        The will delete files request is sent from the client to the server before files
-        are actually deleted as long as the deletion is triggered from within the client.
+        The will delete files request is sent from the client to the server before files are actually
+        deleted as long as the deletion is triggered from within the client.
 
         @since 3.16.0
         """
@@ -2021,7 +1947,7 @@ class LanguageClient(Client):
 
         self.protocol.notify("workspace/didDeleteFiles", params)
 
-    def workspace_did_rename_files(self, params: RenameFilesParams) -> None:
+    def workspace_did_rename_files(self, params: types.RenameFilesParams) -> None:
         """Send a ``workspace/didRenameFiles`` notification.
 
         The did rename files notification is sent from the client to the server when

--- a/pygls/lsp/client.py
+++ b/pygls/lsp/client.py
@@ -31,7 +31,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CallHierarchyIncomingCallsParams,
         callback: Optional[Callable[[Optional[List[types.CallHierarchyIncomingCall]]], None]] = None,
     ) -> Future:
-        """Make a ``callHierarchy/incomingCalls`` request.
+        """Make a :lsp:`callHierarchy/incomingCalls` request.
 
         A request to resolve the incoming calls for a given `CallHierarchyItem`.
 
@@ -46,7 +46,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CallHierarchyIncomingCallsParams,
     ) -> Optional[List[types.CallHierarchyIncomingCall]]:
-        """Make a ``callHierarchy/incomingCalls`` request.
+        """Make a :lsp:`callHierarchy/incomingCalls` request.
 
         A request to resolve the incoming calls for a given `CallHierarchyItem`.
 
@@ -62,7 +62,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CallHierarchyOutgoingCallsParams,
         callback: Optional[Callable[[Optional[List[types.CallHierarchyOutgoingCall]]], None]] = None,
     ) -> Future:
-        """Make a ``callHierarchy/outgoingCalls`` request.
+        """Make a :lsp:`callHierarchy/outgoingCalls` request.
 
         A request to resolve the outgoing calls for a given `CallHierarchyItem`.
 
@@ -77,7 +77,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CallHierarchyOutgoingCallsParams,
     ) -> Optional[List[types.CallHierarchyOutgoingCall]]:
-        """Make a ``callHierarchy/outgoingCalls`` request.
+        """Make a :lsp:`callHierarchy/outgoingCalls` request.
 
         A request to resolve the outgoing calls for a given `CallHierarchyItem`.
 
@@ -93,7 +93,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CodeAction,
         callback: Optional[Callable[[types.CodeAction], None]] = None,
     ) -> Future:
-        """Make a ``codeAction/resolve`` request.
+        """Make a :lsp:`codeAction/resolve` request.
 
         Request to resolve additional information for a given code action.The request's
         parameter is of type {@link CodeAction} the response
@@ -108,7 +108,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CodeAction,
     ) -> types.CodeAction:
-        """Make a ``codeAction/resolve`` request.
+        """Make a :lsp:`codeAction/resolve` request.
 
         Request to resolve additional information for a given code action.The request's
         parameter is of type {@link CodeAction} the response
@@ -124,7 +124,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CodeLens,
         callback: Optional[Callable[[types.CodeLens], None]] = None,
     ) -> Future:
-        """Make a ``codeLens/resolve`` request.
+        """Make a :lsp:`codeLens/resolve` request.
 
         A request to resolve a command for a given code lens.
         """
@@ -137,7 +137,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CodeLens,
     ) -> types.CodeLens:
-        """Make a ``codeLens/resolve`` request.
+        """Make a :lsp:`codeLens/resolve` request.
 
         A request to resolve a command for a given code lens.
         """
@@ -151,7 +151,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CompletionItem,
         callback: Optional[Callable[[types.CompletionItem], None]] = None,
     ) -> Future:
-        """Make a ``completionItem/resolve`` request.
+        """Make a :lsp:`completionItem/resolve` request.
 
         Request to resolve additional information for a given completion item.The request's
         parameter is of type {@link CompletionItem} the response
@@ -166,7 +166,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CompletionItem,
     ) -> types.CompletionItem:
-        """Make a ``completionItem/resolve`` request.
+        """Make a :lsp:`completionItem/resolve` request.
 
         Request to resolve additional information for a given completion item.The request's
         parameter is of type {@link CompletionItem} the response
@@ -182,7 +182,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentLink,
         callback: Optional[Callable[[types.DocumentLink], None]] = None,
     ) -> Future:
-        """Make a ``documentLink/resolve`` request.
+        """Make a :lsp:`documentLink/resolve` request.
 
         Request to resolve additional information for a given document link. The request's
         parameter is of type {@link DocumentLink} the response
@@ -197,7 +197,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentLink,
     ) -> types.DocumentLink:
-        """Make a ``documentLink/resolve`` request.
+        """Make a :lsp:`documentLink/resolve` request.
 
         Request to resolve additional information for a given document link. The request's
         parameter is of type {@link DocumentLink} the response
@@ -213,7 +213,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.InitializeParams,
         callback: Optional[Callable[[types.InitializeResult], None]] = None,
     ) -> Future:
-        """Make a ``initialize`` request.
+        """Make a :lsp:`initialize` request.
 
         The initialize request is sent from the client to the server.
         It is sent once as the request after starting up the server.
@@ -230,7 +230,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.InitializeParams,
     ) -> types.InitializeResult:
-        """Make a ``initialize`` request.
+        """Make a :lsp:`initialize` request.
 
         The initialize request is sent from the client to the server.
         It is sent once as the request after starting up the server.
@@ -248,7 +248,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.InlayHint,
         callback: Optional[Callable[[types.InlayHint], None]] = None,
     ) -> Future:
-        """Make a ``inlayHint/resolve`` request.
+        """Make a :lsp:`inlayHint/resolve` request.
 
         A request to resolve additional properties for an inlay hint.
         The request's parameter is of type {@link InlayHint}, the response is
@@ -265,7 +265,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.InlayHint,
     ) -> types.InlayHint:
-        """Make a ``inlayHint/resolve`` request.
+        """Make a :lsp:`inlayHint/resolve` request.
 
         A request to resolve additional properties for an inlay hint.
         The request's parameter is of type {@link InlayHint}, the response is
@@ -283,7 +283,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: None,
         callback: Optional[Callable[[None], None]] = None,
     ) -> Future:
-        """Make a ``shutdown`` request.
+        """Make a :lsp:`shutdown` request.
 
         A shutdown request is sent from the client to the server.
         It is sent once when the client decides to shutdown the
@@ -299,7 +299,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: None,
     ) -> None:
-        """Make a ``shutdown`` request.
+        """Make a :lsp:`shutdown` request.
 
         A shutdown request is sent from the client to the server.
         It is sent once when the client decides to shutdown the
@@ -316,7 +316,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CodeActionParams,
         callback: Optional[Callable[[Optional[List[Union[types.Command, types.CodeAction]]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/codeAction`` request.
+        """Make a :lsp:`textDocument/codeAction` request.
 
         A request to provide commands for the given text document and range.
         """
@@ -329,7 +329,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CodeActionParams,
     ) -> Optional[List[Union[types.Command, types.CodeAction]]]:
-        """Make a ``textDocument/codeAction`` request.
+        """Make a :lsp:`textDocument/codeAction` request.
 
         A request to provide commands for the given text document and range.
         """
@@ -343,7 +343,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CodeLensParams,
         callback: Optional[Callable[[Optional[List[types.CodeLens]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/codeLens`` request.
+        """Make a :lsp:`textDocument/codeLens` request.
 
         A request to provide code lens for the given text document.
         """
@@ -356,7 +356,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CodeLensParams,
     ) -> Optional[List[types.CodeLens]]:
-        """Make a ``textDocument/codeLens`` request.
+        """Make a :lsp:`textDocument/codeLens` request.
 
         A request to provide code lens for the given text document.
         """
@@ -370,7 +370,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.ColorPresentationParams,
         callback: Optional[Callable[[List[types.ColorPresentation]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/colorPresentation`` request.
+        """Make a :lsp:`textDocument/colorPresentation` request.
 
         A request to list all presentation for a color. The request's
         parameter is of type {@link ColorPresentationParams} the
@@ -386,7 +386,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.ColorPresentationParams,
     ) -> List[types.ColorPresentation]:
-        """Make a ``textDocument/colorPresentation`` request.
+        """Make a :lsp:`textDocument/colorPresentation` request.
 
         A request to list all presentation for a color. The request's
         parameter is of type {@link ColorPresentationParams} the
@@ -403,7 +403,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CompletionParams,
         callback: Optional[Callable[[Union[List[types.CompletionItem], types.CompletionList, None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/completion`` request.
+        """Make a :lsp:`textDocument/completion` request.
 
         Request to request completion at a given text document position. The request's
         parameter is of type {@link TextDocumentPosition} the response
@@ -424,7 +424,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CompletionParams,
     ) -> Union[List[types.CompletionItem], types.CompletionList, None]:
-        """Make a ``textDocument/completion`` request.
+        """Make a :lsp:`textDocument/completion` request.
 
         Request to request completion at a given text document position. The request's
         parameter is of type {@link TextDocumentPosition} the response
@@ -446,7 +446,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DeclarationParams,
         callback: Optional[Callable[[Union[types.Location, List[types.Location], List[types.LocationLink], None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/declaration`` request.
+        """Make a :lsp:`textDocument/declaration` request.
 
         A request to resolve the type definition locations of a symbol at a given text
         document position. The request's parameter is of type {@link TextDocumentPositionParams}
@@ -462,7 +462,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DeclarationParams,
     ) -> Union[types.Location, List[types.Location], List[types.LocationLink], None]:
-        """Make a ``textDocument/declaration`` request.
+        """Make a :lsp:`textDocument/declaration` request.
 
         A request to resolve the type definition locations of a symbol at a given text
         document position. The request's parameter is of type {@link TextDocumentPositionParams}
@@ -479,7 +479,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DefinitionParams,
         callback: Optional[Callable[[Union[types.Location, List[types.Location], List[types.LocationLink], None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/definition`` request.
+        """Make a :lsp:`textDocument/definition` request.
 
         A request to resolve the definition location of a symbol at a given text
         document position. The request's parameter is of type {@link TextDocumentPosition}
@@ -495,7 +495,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DefinitionParams,
     ) -> Union[types.Location, List[types.Location], List[types.LocationLink], None]:
-        """Make a ``textDocument/definition`` request.
+        """Make a :lsp:`textDocument/definition` request.
 
         A request to resolve the definition location of a symbol at a given text
         document position. The request's parameter is of type {@link TextDocumentPosition}
@@ -512,7 +512,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentDiagnosticParams,
         callback: Optional[Callable[[Union[types.RelatedFullDocumentDiagnosticReport, types.RelatedUnchangedDocumentDiagnosticReport]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/diagnostic`` request.
+        """Make a :lsp:`textDocument/diagnostic` request.
 
         The document diagnostic request definition.
 
@@ -527,7 +527,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentDiagnosticParams,
     ) -> Union[types.RelatedFullDocumentDiagnosticReport, types.RelatedUnchangedDocumentDiagnosticReport]:
-        """Make a ``textDocument/diagnostic`` request.
+        """Make a :lsp:`textDocument/diagnostic` request.
 
         The document diagnostic request definition.
 
@@ -543,7 +543,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentColorParams,
         callback: Optional[Callable[[List[types.ColorInformation]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/documentColor`` request.
+        """Make a :lsp:`textDocument/documentColor` request.
 
         A request to list all color symbols found in a given text document. The request's
         parameter is of type {@link DocumentColorParams} the
@@ -559,7 +559,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentColorParams,
     ) -> List[types.ColorInformation]:
-        """Make a ``textDocument/documentColor`` request.
+        """Make a :lsp:`textDocument/documentColor` request.
 
         A request to list all color symbols found in a given text document. The request's
         parameter is of type {@link DocumentColorParams} the
@@ -576,7 +576,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentHighlightParams,
         callback: Optional[Callable[[Optional[List[types.DocumentHighlight]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/documentHighlight`` request.
+        """Make a :lsp:`textDocument/documentHighlight` request.
 
         Request to resolve a {@link DocumentHighlight} for a given
         text document position. The request's parameter is of type {@link TextDocumentPosition}
@@ -592,7 +592,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentHighlightParams,
     ) -> Optional[List[types.DocumentHighlight]]:
-        """Make a ``textDocument/documentHighlight`` request.
+        """Make a :lsp:`textDocument/documentHighlight` request.
 
         Request to resolve a {@link DocumentHighlight} for a given
         text document position. The request's parameter is of type {@link TextDocumentPosition}
@@ -609,7 +609,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentLinkParams,
         callback: Optional[Callable[[Optional[List[types.DocumentLink]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/documentLink`` request.
+        """Make a :lsp:`textDocument/documentLink` request.
 
         A request to provide document links
         """
@@ -622,7 +622,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentLinkParams,
     ) -> Optional[List[types.DocumentLink]]:
-        """Make a ``textDocument/documentLink`` request.
+        """Make a :lsp:`textDocument/documentLink` request.
 
         A request to provide document links
         """
@@ -636,7 +636,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentSymbolParams,
         callback: Optional[Callable[[Union[List[types.SymbolInformation], List[types.DocumentSymbol], None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/documentSymbol`` request.
+        """Make a :lsp:`textDocument/documentSymbol` request.
 
         A request to list all symbols found in a given text document. The request's
         parameter is of type {@link TextDocumentIdentifier} the
@@ -652,7 +652,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentSymbolParams,
     ) -> Union[List[types.SymbolInformation], List[types.DocumentSymbol], None]:
-        """Make a ``textDocument/documentSymbol`` request.
+        """Make a :lsp:`textDocument/documentSymbol` request.
 
         A request to list all symbols found in a given text document. The request's
         parameter is of type {@link TextDocumentIdentifier} the
@@ -669,7 +669,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.FoldingRangeParams,
         callback: Optional[Callable[[Optional[List[types.FoldingRange]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/foldingRange`` request.
+        """Make a :lsp:`textDocument/foldingRange` request.
 
         A request to provide folding ranges in a document. The request's
         parameter is of type {@link FoldingRangeParams}, the
@@ -685,7 +685,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.FoldingRangeParams,
     ) -> Optional[List[types.FoldingRange]]:
-        """Make a ``textDocument/foldingRange`` request.
+        """Make a :lsp:`textDocument/foldingRange` request.
 
         A request to provide folding ranges in a document. The request's
         parameter is of type {@link FoldingRangeParams}, the
@@ -702,7 +702,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentFormattingParams,
         callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/formatting`` request.
+        """Make a :lsp:`textDocument/formatting` request.
 
         A request to format a whole document.
         """
@@ -715,7 +715,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentFormattingParams,
     ) -> Optional[List[types.TextEdit]]:
-        """Make a ``textDocument/formatting`` request.
+        """Make a :lsp:`textDocument/formatting` request.
 
         A request to format a whole document.
         """
@@ -729,7 +729,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.HoverParams,
         callback: Optional[Callable[[Optional[types.Hover]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/hover`` request.
+        """Make a :lsp:`textDocument/hover` request.
 
         Request to request hover information at a given text document position. The request's
         parameter is of type {@link TextDocumentPosition} the response is of
@@ -744,7 +744,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.HoverParams,
     ) -> Optional[types.Hover]:
-        """Make a ``textDocument/hover`` request.
+        """Make a :lsp:`textDocument/hover` request.
 
         Request to request hover information at a given text document position. The request's
         parameter is of type {@link TextDocumentPosition} the response is of
@@ -760,7 +760,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.ImplementationParams,
         callback: Optional[Callable[[Union[types.Location, List[types.Location], List[types.LocationLink], None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/implementation`` request.
+        """Make a :lsp:`textDocument/implementation` request.
 
         A request to resolve the implementation locations of a symbol at a given text
         document position. The request's parameter is of type {@link TextDocumentPositionParams}
@@ -775,7 +775,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.ImplementationParams,
     ) -> Union[types.Location, List[types.Location], List[types.LocationLink], None]:
-        """Make a ``textDocument/implementation`` request.
+        """Make a :lsp:`textDocument/implementation` request.
 
         A request to resolve the implementation locations of a symbol at a given text
         document position. The request's parameter is of type {@link TextDocumentPositionParams}
@@ -791,7 +791,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.InlayHintParams,
         callback: Optional[Callable[[Optional[List[types.InlayHint]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/inlayHint`` request.
+        """Make a :lsp:`textDocument/inlayHint` request.
 
         A request to provide inlay hints in a document. The request's parameter is of
         type {@link InlayHintsParams}, the response is of type
@@ -808,7 +808,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.InlayHintParams,
     ) -> Optional[List[types.InlayHint]]:
-        """Make a ``textDocument/inlayHint`` request.
+        """Make a :lsp:`textDocument/inlayHint` request.
 
         A request to provide inlay hints in a document. The request's parameter is of
         type {@link InlayHintsParams}, the response is of type
@@ -826,7 +826,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.InlineCompletionParams,
         callback: Optional[Callable[[Union[types.InlineCompletionList, List[types.InlineCompletionItem], None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/inlineCompletion`` request.
+        """Make a :lsp:`textDocument/inlineCompletion` request.
 
         A request to provide inline completions in a document. The request's parameter is of
         type {@link InlineCompletionParams}, the response is of type
@@ -844,7 +844,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.InlineCompletionParams,
     ) -> Union[types.InlineCompletionList, List[types.InlineCompletionItem], None]:
-        """Make a ``textDocument/inlineCompletion`` request.
+        """Make a :lsp:`textDocument/inlineCompletion` request.
 
         A request to provide inline completions in a document. The request's parameter is of
         type {@link InlineCompletionParams}, the response is of type
@@ -863,7 +863,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.InlineValueParams,
         callback: Optional[Callable[[Optional[List[Union[types.InlineValueText, types.InlineValueVariableLookup, types.InlineValueEvaluatableExpression]]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/inlineValue`` request.
+        """Make a :lsp:`textDocument/inlineValue` request.
 
         A request to provide inline values in a document. The request's parameter is of
         type {@link InlineValueParams}, the response is of type
@@ -880,7 +880,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.InlineValueParams,
     ) -> Optional[List[Union[types.InlineValueText, types.InlineValueVariableLookup, types.InlineValueEvaluatableExpression]]]:
-        """Make a ``textDocument/inlineValue`` request.
+        """Make a :lsp:`textDocument/inlineValue` request.
 
         A request to provide inline values in a document. The request's parameter is of
         type {@link InlineValueParams}, the response is of type
@@ -898,7 +898,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.LinkedEditingRangeParams,
         callback: Optional[Callable[[Optional[types.LinkedEditingRanges]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/linkedEditingRange`` request.
+        """Make a :lsp:`textDocument/linkedEditingRange` request.
 
         A request to provide ranges that can be edited together.
 
@@ -913,7 +913,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.LinkedEditingRangeParams,
     ) -> Optional[types.LinkedEditingRanges]:
-        """Make a ``textDocument/linkedEditingRange`` request.
+        """Make a :lsp:`textDocument/linkedEditingRange` request.
 
         A request to provide ranges that can be edited together.
 
@@ -929,7 +929,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.MonikerParams,
         callback: Optional[Callable[[Optional[List[types.Moniker]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/moniker`` request.
+        """Make a :lsp:`textDocument/moniker` request.
 
         A request to get the moniker of a symbol at a given text document position.
         The request parameter is of type {@link TextDocumentPositionParams}.
@@ -944,7 +944,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.MonikerParams,
     ) -> Optional[List[types.Moniker]]:
-        """Make a ``textDocument/moniker`` request.
+        """Make a :lsp:`textDocument/moniker` request.
 
         A request to get the moniker of a symbol at a given text document position.
         The request parameter is of type {@link TextDocumentPositionParams}.
@@ -960,7 +960,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentOnTypeFormattingParams,
         callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/onTypeFormatting`` request.
+        """Make a :lsp:`textDocument/onTypeFormatting` request.
 
         A request to format a document on type.
         """
@@ -973,7 +973,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentOnTypeFormattingParams,
     ) -> Optional[List[types.TextEdit]]:
-        """Make a ``textDocument/onTypeFormatting`` request.
+        """Make a :lsp:`textDocument/onTypeFormatting` request.
 
         A request to format a document on type.
         """
@@ -987,7 +987,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CallHierarchyPrepareParams,
         callback: Optional[Callable[[Optional[List[types.CallHierarchyItem]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/prepareCallHierarchy`` request.
+        """Make a :lsp:`textDocument/prepareCallHierarchy` request.
 
         A request to result a `CallHierarchyItem` in a document at a given position.
         Can be used as an input to an incoming or outgoing call hierarchy.
@@ -1003,7 +1003,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CallHierarchyPrepareParams,
     ) -> Optional[List[types.CallHierarchyItem]]:
-        """Make a ``textDocument/prepareCallHierarchy`` request.
+        """Make a :lsp:`textDocument/prepareCallHierarchy` request.
 
         A request to result a `CallHierarchyItem` in a document at a given position.
         Can be used as an input to an incoming or outgoing call hierarchy.
@@ -1020,7 +1020,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.PrepareRenameParams,
         callback: Optional[Callable[[Union[types.Range, types.PrepareRenameResult_Type1, types.PrepareRenameResult_Type2, None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/prepareRename`` request.
+        """Make a :lsp:`textDocument/prepareRename` request.
 
         A request to test and perform the setup necessary for a rename.
 
@@ -1035,7 +1035,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.PrepareRenameParams,
     ) -> Union[types.Range, types.PrepareRenameResult_Type1, types.PrepareRenameResult_Type2, None]:
-        """Make a ``textDocument/prepareRename`` request.
+        """Make a :lsp:`textDocument/prepareRename` request.
 
         A request to test and perform the setup necessary for a rename.
 
@@ -1051,7 +1051,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.TypeHierarchyPrepareParams,
         callback: Optional[Callable[[Optional[List[types.TypeHierarchyItem]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/prepareTypeHierarchy`` request.
+        """Make a :lsp:`textDocument/prepareTypeHierarchy` request.
 
         A request to result a `TypeHierarchyItem` in a document at a given position.
         Can be used as an input to a subtypes or supertypes type hierarchy.
@@ -1067,7 +1067,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.TypeHierarchyPrepareParams,
     ) -> Optional[List[types.TypeHierarchyItem]]:
-        """Make a ``textDocument/prepareTypeHierarchy`` request.
+        """Make a :lsp:`textDocument/prepareTypeHierarchy` request.
 
         A request to result a `TypeHierarchyItem` in a document at a given position.
         Can be used as an input to a subtypes or supertypes type hierarchy.
@@ -1084,7 +1084,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentRangesFormattingParams,
         callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/rangesFormatting`` request.
+        """Make a :lsp:`textDocument/rangesFormatting` request.
 
         A request to format ranges in a document.
 
@@ -1100,7 +1100,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentRangesFormattingParams,
     ) -> Optional[List[types.TextEdit]]:
-        """Make a ``textDocument/rangesFormatting`` request.
+        """Make a :lsp:`textDocument/rangesFormatting` request.
 
         A request to format ranges in a document.
 
@@ -1117,7 +1117,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DocumentRangeFormattingParams,
         callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/rangeFormatting`` request.
+        """Make a :lsp:`textDocument/rangeFormatting` request.
 
         A request to format a range in a document.
         """
@@ -1130,7 +1130,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DocumentRangeFormattingParams,
     ) -> Optional[List[types.TextEdit]]:
-        """Make a ``textDocument/rangeFormatting`` request.
+        """Make a :lsp:`textDocument/rangeFormatting` request.
 
         A request to format a range in a document.
         """
@@ -1144,7 +1144,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.ReferenceParams,
         callback: Optional[Callable[[Optional[List[types.Location]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/references`` request.
+        """Make a :lsp:`textDocument/references` request.
 
         A request to resolve project-wide references for the symbol denoted
         by the given text document position. The request's parameter is of
@@ -1160,7 +1160,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.ReferenceParams,
     ) -> Optional[List[types.Location]]:
-        """Make a ``textDocument/references`` request.
+        """Make a :lsp:`textDocument/references` request.
 
         A request to resolve project-wide references for the symbol denoted
         by the given text document position. The request's parameter is of
@@ -1177,7 +1177,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.RenameParams,
         callback: Optional[Callable[[Optional[types.WorkspaceEdit]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/rename`` request.
+        """Make a :lsp:`textDocument/rename` request.
 
         A request to rename a symbol.
         """
@@ -1190,7 +1190,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.RenameParams,
     ) -> Optional[types.WorkspaceEdit]:
-        """Make a ``textDocument/rename`` request.
+        """Make a :lsp:`textDocument/rename` request.
 
         A request to rename a symbol.
         """
@@ -1204,7 +1204,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.SelectionRangeParams,
         callback: Optional[Callable[[Optional[List[types.SelectionRange]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/selectionRange`` request.
+        """Make a :lsp:`textDocument/selectionRange` request.
 
         A request to provide selection ranges in a document. The request's
         parameter is of type {@link SelectionRangeParams}, the
@@ -1220,7 +1220,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.SelectionRangeParams,
     ) -> Optional[List[types.SelectionRange]]:
-        """Make a ``textDocument/selectionRange`` request.
+        """Make a :lsp:`textDocument/selectionRange` request.
 
         A request to provide selection ranges in a document. The request's
         parameter is of type {@link SelectionRangeParams}, the
@@ -1237,7 +1237,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.SemanticTokensParams,
         callback: Optional[Callable[[Optional[types.SemanticTokens]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/semanticTokens/full`` request.
+        """Make a :lsp:`textDocument/semanticTokens/full` request.
 
         @since 3.16.0
         """
@@ -1250,7 +1250,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.SemanticTokensParams,
     ) -> Optional[types.SemanticTokens]:
-        """Make a ``textDocument/semanticTokens/full`` request.
+        """Make a :lsp:`textDocument/semanticTokens/full` request.
 
         @since 3.16.0
         """
@@ -1264,7 +1264,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.SemanticTokensDeltaParams,
         callback: Optional[Callable[[Union[types.SemanticTokens, types.SemanticTokensDelta, None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/semanticTokens/full/delta`` request.
+        """Make a :lsp:`textDocument/semanticTokens/full/delta` request.
 
         @since 3.16.0
         """
@@ -1277,7 +1277,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.SemanticTokensDeltaParams,
     ) -> Union[types.SemanticTokens, types.SemanticTokensDelta, None]:
-        """Make a ``textDocument/semanticTokens/full/delta`` request.
+        """Make a :lsp:`textDocument/semanticTokens/full/delta` request.
 
         @since 3.16.0
         """
@@ -1291,7 +1291,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.SemanticTokensRangeParams,
         callback: Optional[Callable[[Optional[types.SemanticTokens]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/semanticTokens/range`` request.
+        """Make a :lsp:`textDocument/semanticTokens/range` request.
 
         @since 3.16.0
         """
@@ -1304,7 +1304,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.SemanticTokensRangeParams,
     ) -> Optional[types.SemanticTokens]:
-        """Make a ``textDocument/semanticTokens/range`` request.
+        """Make a :lsp:`textDocument/semanticTokens/range` request.
 
         @since 3.16.0
         """
@@ -1318,7 +1318,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.SignatureHelpParams,
         callback: Optional[Callable[[Optional[types.SignatureHelp]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/signatureHelp`` request.
+        """Make a :lsp:`textDocument/signatureHelp` request.
 
 
         """
@@ -1331,7 +1331,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.SignatureHelpParams,
     ) -> Optional[types.SignatureHelp]:
-        """Make a ``textDocument/signatureHelp`` request.
+        """Make a :lsp:`textDocument/signatureHelp` request.
 
 
         """
@@ -1345,7 +1345,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.TypeDefinitionParams,
         callback: Optional[Callable[[Union[types.Location, List[types.Location], List[types.LocationLink], None]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/typeDefinition`` request.
+        """Make a :lsp:`textDocument/typeDefinition` request.
 
         A request to resolve the type definition locations of a symbol at a given text
         document position. The request's parameter is of type {@link TextDocumentPositionParams}
@@ -1360,7 +1360,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.TypeDefinitionParams,
     ) -> Union[types.Location, List[types.Location], List[types.LocationLink], None]:
-        """Make a ``textDocument/typeDefinition`` request.
+        """Make a :lsp:`textDocument/typeDefinition` request.
 
         A request to resolve the type definition locations of a symbol at a given text
         document position. The request's parameter is of type {@link TextDocumentPositionParams}
@@ -1376,7 +1376,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.WillSaveTextDocumentParams,
         callback: Optional[Callable[[Optional[List[types.TextEdit]]], None]] = None,
     ) -> Future:
-        """Make a ``textDocument/willSaveWaitUntil`` request.
+        """Make a :lsp:`textDocument/willSaveWaitUntil` request.
 
         A document will save request is sent from the client to the server before
         the document is actually saved. The request can return an array of TextEdits
@@ -1394,7 +1394,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.WillSaveTextDocumentParams,
     ) -> Optional[List[types.TextEdit]]:
-        """Make a ``textDocument/willSaveWaitUntil`` request.
+        """Make a :lsp:`textDocument/willSaveWaitUntil` request.
 
         A document will save request is sent from the client to the server before
         the document is actually saved. The request can return an array of TextEdits
@@ -1413,7 +1413,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.TypeHierarchySubtypesParams,
         callback: Optional[Callable[[Optional[List[types.TypeHierarchyItem]]], None]] = None,
     ) -> Future:
-        """Make a ``typeHierarchy/subtypes`` request.
+        """Make a :lsp:`typeHierarchy/subtypes` request.
 
         A request to resolve the subtypes for a given `TypeHierarchyItem`.
 
@@ -1428,7 +1428,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.TypeHierarchySubtypesParams,
     ) -> Optional[List[types.TypeHierarchyItem]]:
-        """Make a ``typeHierarchy/subtypes`` request.
+        """Make a :lsp:`typeHierarchy/subtypes` request.
 
         A request to resolve the subtypes for a given `TypeHierarchyItem`.
 
@@ -1444,7 +1444,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.TypeHierarchySupertypesParams,
         callback: Optional[Callable[[Optional[List[types.TypeHierarchyItem]]], None]] = None,
     ) -> Future:
-        """Make a ``typeHierarchy/supertypes`` request.
+        """Make a :lsp:`typeHierarchy/supertypes` request.
 
         A request to resolve the supertypes for a given `TypeHierarchyItem`.
 
@@ -1459,7 +1459,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.TypeHierarchySupertypesParams,
     ) -> Optional[List[types.TypeHierarchyItem]]:
-        """Make a ``typeHierarchy/supertypes`` request.
+        """Make a :lsp:`typeHierarchy/supertypes` request.
 
         A request to resolve the supertypes for a given `TypeHierarchyItem`.
 
@@ -1475,7 +1475,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.WorkspaceDiagnosticParams,
         callback: Optional[Callable[[types.WorkspaceDiagnosticReport], None]] = None,
     ) -> Future:
-        """Make a ``workspace/diagnostic`` request.
+        """Make a :lsp:`workspace/diagnostic` request.
 
         The workspace diagnostic request definition.
 
@@ -1490,7 +1490,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.WorkspaceDiagnosticParams,
     ) -> types.WorkspaceDiagnosticReport:
-        """Make a ``workspace/diagnostic`` request.
+        """Make a :lsp:`workspace/diagnostic` request.
 
         The workspace diagnostic request definition.
 
@@ -1506,7 +1506,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.ExecuteCommandParams,
         callback: Optional[Callable[[Optional[Any]], None]] = None,
     ) -> Future:
-        """Make a ``workspace/executeCommand`` request.
+        """Make a :lsp:`workspace/executeCommand` request.
 
         A request send from the client to the server to execute a command. The request might return
         a workspace edit which the client will apply to the workspace.
@@ -1520,7 +1520,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.ExecuteCommandParams,
     ) -> Optional[Any]:
-        """Make a ``workspace/executeCommand`` request.
+        """Make a :lsp:`workspace/executeCommand` request.
 
         A request send from the client to the server to execute a command. The request might return
         a workspace edit which the client will apply to the workspace.
@@ -1535,7 +1535,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.WorkspaceSymbolParams,
         callback: Optional[Callable[[Union[List[types.SymbolInformation], List[types.WorkspaceSymbol], None]], None]] = None,
     ) -> Future:
-        """Make a ``workspace/symbol`` request.
+        """Make a :lsp:`workspace/symbol` request.
 
         A request to list project-wide symbols matching the query string given
         by the {@link WorkspaceSymbolParams}. The response is
@@ -1555,7 +1555,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.WorkspaceSymbolParams,
     ) -> Union[List[types.SymbolInformation], List[types.WorkspaceSymbol], None]:
-        """Make a ``workspace/symbol`` request.
+        """Make a :lsp:`workspace/symbol` request.
 
         A request to list project-wide symbols matching the query string given
         by the {@link WorkspaceSymbolParams}. The response is
@@ -1576,7 +1576,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.WorkspaceSymbol,
         callback: Optional[Callable[[types.WorkspaceSymbol], None]] = None,
     ) -> Future:
-        """Make a ``workspaceSymbol/resolve`` request.
+        """Make a :lsp:`workspaceSymbol/resolve` request.
 
         A request to resolve the range inside the workspace
         symbol's location.
@@ -1592,7 +1592,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.WorkspaceSymbol,
     ) -> types.WorkspaceSymbol:
-        """Make a ``workspaceSymbol/resolve`` request.
+        """Make a :lsp:`workspaceSymbol/resolve` request.
 
         A request to resolve the range inside the workspace
         symbol's location.
@@ -1609,7 +1609,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.CreateFilesParams,
         callback: Optional[Callable[[Optional[types.WorkspaceEdit]], None]] = None,
     ) -> Future:
-        """Make a ``workspace/willCreateFiles`` request.
+        """Make a :lsp:`workspace/willCreateFiles` request.
 
         The will create files request is sent from the client to the server before files are actually
         created as long as the creation is triggered from within the client.
@@ -1629,7 +1629,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.CreateFilesParams,
     ) -> Optional[types.WorkspaceEdit]:
-        """Make a ``workspace/willCreateFiles`` request.
+        """Make a :lsp:`workspace/willCreateFiles` request.
 
         The will create files request is sent from the client to the server before files are actually
         created as long as the creation is triggered from within the client.
@@ -1650,7 +1650,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.DeleteFilesParams,
         callback: Optional[Callable[[Optional[types.WorkspaceEdit]], None]] = None,
     ) -> Future:
-        """Make a ``workspace/willDeleteFiles`` request.
+        """Make a :lsp:`workspace/willDeleteFiles` request.
 
         The did delete files notification is sent from the client to the server when
         files were deleted from within the client.
@@ -1666,7 +1666,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.DeleteFilesParams,
     ) -> Optional[types.WorkspaceEdit]:
-        """Make a ``workspace/willDeleteFiles`` request.
+        """Make a :lsp:`workspace/willDeleteFiles` request.
 
         The did delete files notification is sent from the client to the server when
         files were deleted from within the client.
@@ -1683,7 +1683,7 @@ class BaseLanguageClient(JsonRPCClient):
         params: types.RenameFilesParams,
         callback: Optional[Callable[[Optional[types.WorkspaceEdit]], None]] = None,
     ) -> Future:
-        """Make a ``workspace/willRenameFiles`` request.
+        """Make a :lsp:`workspace/willRenameFiles` request.
 
         The will rename files request is sent from the client to the server before files are actually
         renamed as long as the rename is triggered from within the client.
@@ -1699,7 +1699,7 @@ class BaseLanguageClient(JsonRPCClient):
         self,
         params: types.RenameFilesParams,
     ) -> Optional[types.WorkspaceEdit]:
-        """Make a ``workspace/willRenameFiles`` request.
+        """Make a :lsp:`workspace/willRenameFiles` request.
 
         The will rename files request is sent from the client to the server before files are actually
         renamed as long as the rename is triggered from within the client.
@@ -1712,7 +1712,7 @@ class BaseLanguageClient(JsonRPCClient):
         return await self.protocol.send_request_async("workspace/willRenameFiles", params)
 
     def cancel_request(self, params: types.CancelParams) -> None:
-        """Send a ``$/cancelRequest`` notification.
+        """Send a :lsp:`$/cancelRequest` notification.
 
 
         """
@@ -1722,7 +1722,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("$/cancelRequest", params)
 
     def exit(self, params: None) -> None:
-        """Send a ``exit`` notification.
+        """Send a :lsp:`exit` notification.
 
         The exit event is sent from the client to the server to
         ask the server to exit its process.
@@ -1733,7 +1733,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("exit", params)
 
     def initialized(self, params: types.InitializedParams) -> None:
-        """Send a ``initialized`` notification.
+        """Send a :lsp:`initialized` notification.
 
         The initialized notification is sent from the client to the
         server after the client is fully initialized and the server
@@ -1745,7 +1745,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("initialized", params)
 
     def notebook_document_did_change(self, params: types.DidChangeNotebookDocumentParams) -> None:
-        """Send a ``notebookDocument/didChange`` notification.
+        """Send a :lsp:`notebookDocument/didChange` notification.
 
 
         """
@@ -1755,7 +1755,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("notebookDocument/didChange", params)
 
     def notebook_document_did_close(self, params: types.DidCloseNotebookDocumentParams) -> None:
-        """Send a ``notebookDocument/didClose`` notification.
+        """Send a :lsp:`notebookDocument/didClose` notification.
 
         A notification sent when a notebook closes.
 
@@ -1767,7 +1767,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("notebookDocument/didClose", params)
 
     def notebook_document_did_open(self, params: types.DidOpenNotebookDocumentParams) -> None:
-        """Send a ``notebookDocument/didOpen`` notification.
+        """Send a :lsp:`notebookDocument/didOpen` notification.
 
         A notification sent when a notebook opens.
 
@@ -1779,7 +1779,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("notebookDocument/didOpen", params)
 
     def notebook_document_did_save(self, params: types.DidSaveNotebookDocumentParams) -> None:
-        """Send a ``notebookDocument/didSave`` notification.
+        """Send a :lsp:`notebookDocument/didSave` notification.
 
         A notification sent when a notebook document is saved.
 
@@ -1791,7 +1791,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("notebookDocument/didSave", params)
 
     def progress(self, params: types.ProgressParams) -> None:
-        """Send a ``$/progress`` notification.
+        """Send a :lsp:`$/progress` notification.
 
 
         """
@@ -1801,7 +1801,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("$/progress", params)
 
     def set_trace(self, params: types.SetTraceParams) -> None:
-        """Send a ``$/setTrace`` notification.
+        """Send a :lsp:`$/setTrace` notification.
 
 
         """
@@ -1811,7 +1811,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("$/setTrace", params)
 
     def text_document_did_change(self, params: types.DidChangeTextDocumentParams) -> None:
-        """Send a ``textDocument/didChange`` notification.
+        """Send a :lsp:`textDocument/didChange` notification.
 
         The document change notification is sent from the client to the server to signal
         changes to a text document.
@@ -1822,7 +1822,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("textDocument/didChange", params)
 
     def text_document_did_close(self, params: types.DidCloseTextDocumentParams) -> None:
-        """Send a ``textDocument/didClose`` notification.
+        """Send a :lsp:`textDocument/didClose` notification.
 
         The document close notification is sent from the client to the server when
         the document got closed in the client. The document's truth now exists where
@@ -1838,7 +1838,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("textDocument/didClose", params)
 
     def text_document_did_open(self, params: types.DidOpenTextDocumentParams) -> None:
-        """Send a ``textDocument/didOpen`` notification.
+        """Send a :lsp:`textDocument/didOpen` notification.
 
         The document open notification is sent from the client to the server to signal
         newly opened text documents. The document's truth is now managed by the client
@@ -1855,7 +1855,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("textDocument/didOpen", params)
 
     def text_document_did_save(self, params: types.DidSaveTextDocumentParams) -> None:
-        """Send a ``textDocument/didSave`` notification.
+        """Send a :lsp:`textDocument/didSave` notification.
 
         The document save notification is sent from the client to the server when
         the document got saved in the client.
@@ -1866,7 +1866,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("textDocument/didSave", params)
 
     def text_document_will_save(self, params: types.WillSaveTextDocumentParams) -> None:
-        """Send a ``textDocument/willSave`` notification.
+        """Send a :lsp:`textDocument/willSave` notification.
 
         A document will save notification is sent from the client to the server before
         the document is actually saved.
@@ -1877,7 +1877,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("textDocument/willSave", params)
 
     def window_work_done_progress_cancel(self, params: types.WorkDoneProgressCancelParams) -> None:
-        """Send a ``window/workDoneProgress/cancel`` notification.
+        """Send a :lsp:`window/workDoneProgress/cancel` notification.
 
         The `window/workDoneProgress/cancel` notification is sent from  the client to the server to cancel a progress
         initiated on the server side.
@@ -1888,7 +1888,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("window/workDoneProgress/cancel", params)
 
     def workspace_did_change_configuration(self, params: types.DidChangeConfigurationParams) -> None:
-        """Send a ``workspace/didChangeConfiguration`` notification.
+        """Send a :lsp:`workspace/didChangeConfiguration` notification.
 
         The configuration change notification is sent from the client to the server
         when the client's configuration has changed. The notification contains
@@ -1900,7 +1900,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("workspace/didChangeConfiguration", params)
 
     def workspace_did_change_watched_files(self, params: types.DidChangeWatchedFilesParams) -> None:
-        """Send a ``workspace/didChangeWatchedFiles`` notification.
+        """Send a :lsp:`workspace/didChangeWatchedFiles` notification.
 
         The watched files notification is sent from the client to the server when
         the client detects changes to file watched by the language client.
@@ -1911,7 +1911,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("workspace/didChangeWatchedFiles", params)
 
     def workspace_did_change_workspace_folders(self, params: types.DidChangeWorkspaceFoldersParams) -> None:
-        """Send a ``workspace/didChangeWorkspaceFolders`` notification.
+        """Send a :lsp:`workspace/didChangeWorkspaceFolders` notification.
 
         The `workspace/didChangeWorkspaceFolders` notification is sent from the client to the server when the workspace
         folder configuration changes.
@@ -1922,7 +1922,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("workspace/didChangeWorkspaceFolders", params)
 
     def workspace_did_create_files(self, params: types.CreateFilesParams) -> None:
-        """Send a ``workspace/didCreateFiles`` notification.
+        """Send a :lsp:`workspace/didCreateFiles` notification.
 
         The did create files notification is sent from the client to the server when
         files were created from within the client.
@@ -1935,7 +1935,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("workspace/didCreateFiles", params)
 
     def workspace_did_delete_files(self, params: types.DeleteFilesParams) -> None:
-        """Send a ``workspace/didDeleteFiles`` notification.
+        """Send a :lsp:`workspace/didDeleteFiles` notification.
 
         The will delete files request is sent from the client to the server before files are actually
         deleted as long as the deletion is triggered from within the client.
@@ -1948,7 +1948,7 @@ class BaseLanguageClient(JsonRPCClient):
         self.protocol.notify("workspace/didDeleteFiles", params)
 
     def workspace_did_rename_files(self, params: types.RenameFilesParams) -> None:
-        """Send a ``workspace/didRenameFiles`` notification.
+        """Send a :lsp:`workspace/didRenameFiles` notification.
 
         The did rename files notification is sent from the client to the server when
         files were renamed from within the client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.7.9,<4"
-lsprotocol = "2023.0.0a2"
+lsprotocol = "2023.0.0a3"
 typeguard = "^3.0.0"
 websockets = {version = "^11.0.3", optional = true}
 

--- a/scripts/generate_client.py
+++ b/scripts/generate_client.py
@@ -57,7 +57,7 @@ def write_notification(
     return "\n".join(
         [
             f"def {python_name}(self, params: {param_mod}{param_name}) -> None:",
-            f'    """Send a ``{method}`` notification.',
+            f'    """Send a :lsp:`{method}` notification.',
             "",
             textwrap.indent(inspect.getdoc(request) or "", "    "),
             '    """',
@@ -112,7 +112,7 @@ def write_method(
             f"    params: {param_mod}{param_name},",
             f"    callback: Optional[Callable[[{result_type}], None]] = None,",
             ") -> Future:",
-            f'    """Make a ``{method}`` request.',
+            f'    """Make a :lsp:`{method}` request.',
             "",
             textwrap.indent(inspect.getdoc(request) or "", "    "),
             '    """',
@@ -125,7 +125,7 @@ def write_method(
             "    self,",
             f"    params: {param_mod}{param_name},",
             f") -> {result_type}:",
-            f'    """Make a ``{method}`` request.',
+            f'    """Make a :lsp:`{method}` request.',
             "",
             textwrap.indent(inspect.getdoc(request) or "", "    "),
             '    """',

--- a/tests/client.py
+++ b/tests/client.py
@@ -32,7 +32,7 @@ from lsprotocol import types
 from pygls import IS_PYODIDE
 from pygls import uris
 from pygls.exceptions import JsonRpcMethodNotFound
-from pygls.lsp.client import LanguageClient as BaseLanguageClient
+from pygls.lsp.client import BaseLanguageClient
 from pygls.protocol import LanguageServerProtocol
 from pygls.protocol import default_converter
 

--- a/tests/pyodide_testrunner/run.py
+++ b/tests/pyodide_testrunner/run.py
@@ -101,7 +101,9 @@ def main():
         driver_cls, options_cls = BROWSERS[os.environ.get("BROWSER", "chrome")]
 
         options = options_cls()
-        options.headless = "CI" in os.environ
+        if "CI" in os.environ:
+            options.binary_location = "/usr/bin/google-chrome"
+            options.add_argument("--headless")
 
         driver = driver_cls(options=options)
         driver.get(f"http://localhost:{port}?whl={whl}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,7 +22,7 @@ from typing import Union
 import pytest
 from pygls import IS_PYODIDE
 
-from pygls.client import Client
+from pygls.client import JsonRPCClient
 from pygls.exceptions import JsonRpcException, PyglsError
 
 
@@ -34,7 +34,7 @@ SERVERS = pathlib.Path(__file__).parent / "servers"
 async def test_client_detect_server_exit():
     """Ensure that the client detects when the server process exits."""
 
-    class TestClient(Client):
+    class TestClient(JsonRPCClient):
         server_exit_called = False
 
         async def server_exit(self, server: asyncio.subprocess.Process):
@@ -56,7 +56,7 @@ async def test_client_detect_invalid_json():
     """Ensure that the client can detect the case where the server returns invalid
     json."""
 
-    class TestClient(Client):
+    class TestClient(JsonRPCClient):
         report_error_called = False
         future = None
 
@@ -93,7 +93,7 @@ async def test_client_detect_invalid_json():
 async def test_client_large_responses():
     """Ensure that the client can correctly handle large responses from a server."""
 
-    client = Client()
+    client = JsonRPCClient()
     await client.start_io(sys.executable, str(SERVERS / "large_response.py"))
 
     result = await client.protocol.send_request_async("get/numbers", {}, msg_id=1)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This renames the new client objects to something that better reflects their purpose.
- In `pygls/client.py`, `Client` is now called `JsonRPCClient`
- The auto generated `LanguageClient` in `pygls/lsp/client.py` is now called `BaseLanguageClient`

This PR also performs some other house keeping tasks
- Bump `lsprotocol` to `2023.0.0a3` which should include all the fixes required for #356 
- The auto generated client now references LSP types via the `types` module rather than importing them directly which cuts out the 100s of lines of imports at the top of the file
- Update the documentation to include reference API documentation for the `JsonRPCClient` and `BaseLanguageClient`

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://chris.beams.io/posts/git-commit/
