### PR TITLE
fix: ensure server commands can be executed

### DIFF
--- a/examples/servers/json_server.py
+++ b/examples/servers/json_server.py
@@ -41,7 +41,7 @@ class JsonLanguageServer(LanguageServer):
     CMD_SHOW_CONFIGURATION_THREAD = "showConfigurationThread"
     CMD_UNREGISTER_COMPLETIONS = "unregisterCompletions"
 
-    CONFIGURATION_SECTION = "jsonServer"
+    CONFIGURATION_SECTION = "pygls.jsonServer"
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/examples/vscode-playground/package.json
+++ b/examples/vscode-playground/package.json
@@ -35,6 +35,17 @@
     "configuration": [
       {
         "type": "object",
+        "title": "Json Server Configuration",
+        "properties": {
+          "pygls.jsonServer.exampleConfiguration": {
+            "scope": "resource",
+            "type": "string",
+            "default": "You can override this message"
+          }
+        }
+      },
+      {
+        "type": "object",
         "title": "Server Configuration",
         "properties": {
           "pygls.server.cwd": {


### PR DESCRIPTION

![Screenshot_20230901_191518](https://github.com/openlawlibrary/pygls/assets/2675694/f41fedc3-8a3c-4976-adb4-a988951e83c3)


This brings back the ability to execute commands provided by the language server in the `vscode-playground` extension.

Instead of encoding all the commands in the `package.json` file, the extension inspects the `ServerCapabilities` of the `initialize` response to determine which commands a server provides. It then presents a quick pick list of commands the user can choose to run.

This should mean commands (that don't take any arguments at least) now "just work" with the playground extension

This PR also re-defines the example configuration keys in the `packae.json` for  `json_server.py` otherwise VSCode simply responds with `null` when the configuration values are requested

Closes #365 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://chris.beams.io/posts/git-commit/
