### PR TITLE
fix: only show code action when there's no sum

### DIFF
--- a/examples/servers/code_actions.py
+++ b/examples/servers/code_actions.py
@@ -29,7 +29,7 @@ from lsprotocol.types import (
 )
 
 
-ADDITION = re.compile(r"^\s*(\d+)\s*\+\s*(\d+)\s*=\s*$")
+ADDITION = re.compile(r"^\s*(\d+)\s*\+\s*(\d+)\s*=(?=\s*$)")
 server = LanguageServer("code-action-server", "v0.1")
 
 

--- a/examples/servers/code_actions.py
+++ b/examples/servers/code_actions.py
@@ -29,7 +29,7 @@ from lsprotocol.types import (
 )
 
 
-ADDITION = re.compile(r"^\s*(\d+)\s*\+\s*(\d+)\s*=")
+ADDITION = re.compile(r"^\s*(\d+)\s*\+\s*(\d+)\s*=\s*$")
 server = LanguageServer("code-action-server", "v0.1")
 
 


### PR DESCRIPTION
## Description

In examples/code_actions, tighten the ADDITION regex so that the 'Evaluate' code action only appears if there's no sum. Previously, after using the action, the lightbulb remained visible in VSCode and would keep appending the sum to the line, resulting in things like `1 + 1 = 2! 2! 2!`

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://conventionalcommits.org/
