### PR TITLE
refactor: rename server Position to PositionCodec, instantiate it in Workspace

### DIFF
--- a/pygls/workspace/__init__.py
+++ b/pygls/workspace/__init__.py
@@ -5,11 +5,11 @@ from lsprotocol import types
 
 from .workspace import Workspace
 from .text_document import TextDocument
-from .position import Position
+from .position_codec import PositionCodec
 
 Workspace = Workspace
 TextDocument = TextDocument
-Position = Position
+PositionCodec = PositionCodec
 
 # For backwards compatibility
 Document = TextDocument
@@ -17,65 +17,71 @@ Document = TextDocument
 
 def utf16_unit_offset(chars: str):
     warnings.warn(
-        "'utf16_unit_offset' has been deprecated, use "
-        "'Position.utf16_unit_offset' instead",
+        "'utf16_unit_offset' has been deprecated, instead use "
+        "'PositionCodec.utf16_unit_offset' via 'workspace.position_codec' "
+        "or 'text_document.position_codec'",
         DeprecationWarning,
         stacklevel=2,
     )
-    _position = Position()
-    return _position.utf16_unit_offset(chars)
+    _codec = PositionCodec()
+    return _codec.utf16_unit_offset(chars)
 
 
 def utf16_num_units(chars: str):
     warnings.warn(
-        "'utf16_num_units' has been deprecated, use "
-        "'Position.client_num_units' instead",
+        "'utf16_num_units' has been deprecated, instead use "
+        "'PositionCodec.client_num_units' via 'workspace.position_codec' "
+        "or 'text_document.position_codec'",
         DeprecationWarning,
         stacklevel=2,
     )
-    _position = Position()
-    return _position.client_num_units(chars)
+    _codec = PositionCodec()
+    return _codec.client_num_units(chars)
 
 
 def position_from_utf16(lines: List[str], position: types.Position):
     warnings.warn(
-        "'position_from_utf16' has been deprecated, use "
-        "'Position.position_from_client_units' instead",
+        "'position_from_utf16' has been deprecated, instead use "
+        "'PositionCodec.position_from_client_units' via "
+        "'workspace.position_codec' or 'text_document.position_codec'",
         DeprecationWarning,
         stacklevel=2,
     )
-    _position = Position()
-    return _position.position_from_client_units(lines, position)
+    _codec = PositionCodec()
+    return _codec.position_from_client_units(lines, position)
 
 
 def position_to_utf16(lines: List[str], position: types.Position):
     warnings.warn(
-        "'position_to_utf16' has been deprecated, use "
-        "'Position.position_to_client_units' instead",
+        "'position_to_utf16' has been deprecated, instead use "
+        "'PositionCodec.position_to_client_units' via "
+        "'workspace.position_codec' or 'text_document.position_codec'",
         DeprecationWarning,
         stacklevel=2,
     )
-    _position = Position()
-    return _position.position_to_client_units(lines, position)
+    _codec = PositionCodec()
+    return _codec.position_to_client_units(lines, position)
 
 
 def range_from_utf16(lines: List[str], range: types.Range):
     warnings.warn(
-        "'range_from_utf16' has been deprecated, use "
-        "'Position.range_from_client_units' instead",
+        "'range_from_utf16' has been deprecated, instead use "
+        "'PositionCodec.range_from_client_units' via "
+        "'workspace.position_codec' or 'text_document.position_codec'",
         DeprecationWarning,
         stacklevel=2,
     )
-    _position = Position()
-    return _position.range_from_client_units(lines, range)
+    _codec = PositionCodec()
+    return _codec.range_from_client_units(lines, range)
 
 
 def range_to_utf16(lines: List[str], range: types.Range):
     warnings.warn(
-        "'range_to_utf16' has been deprecated, use "
-        "'Position.range_to_client_units' instead",
+        "'range_to_utf16' has been deprecated, instead use "
+        "'PositionCodec.range_to_client_units' via 'workspace.position_codec' "
+        "or 'text_document.position_codec'",
         DeprecationWarning,
         stacklevel=2,
     )
-    _position = Position()
-    return _position.range_to_client_units(lines, range)
+    _codec = PositionCodec()
+    return _codec.range_to_client_units(lines, range)

--- a/pygls/workspace/position_codec.py
+++ b/pygls/workspace/position_codec.py
@@ -25,7 +25,7 @@ from lsprotocol import types
 log = logging.getLogger(__name__)
 
 
-class Position:
+class PositionCodec:
     def __init__(
         self,
         encoding: Optional[
@@ -121,7 +121,9 @@ class Position:
                 break
 
             _current_char = _line[utf32_index]
-            _is_double_width = Position.is_char_beyond_multilingual_plane(_current_char)
+            _is_double_width = PositionCodec.is_char_beyond_multilingual_plane(
+                _current_char
+            )
             if _is_double_width:
                 if self.encoding == types.PositionEncodingKind.Utf32:
                     _client_index += 1

--- a/pygls/workspace/workspace.py
+++ b/pygls/workspace/workspace.py
@@ -30,6 +30,7 @@ from lsprotocol.types import (
 )
 from pygls.uris import to_fs_path, uri_scheme
 from pygls.workspace.text_document import TextDocument
+from pygls.workspace.position_codec import PositionCodec
 
 logger = logging.getLogger(__name__)
 
@@ -60,10 +61,19 @@ class Workspace(object):
         self._folders: Dict[str, WorkspaceFolder] = {}
         self._docs: Dict[str, TextDocument] = {}
         self._position_encoding = position_encoding
+        self._position_codec = PositionCodec(encoding=position_encoding)
 
         if workspace_folders is not None:
             for folder in workspace_folders:
                 self.add_folder(folder)
+
+    @property
+    def position_encoding(self) -> Optional[Union[PositionEncodingKind, str]]:
+        return self._position_encoding
+
+    @property
+    def position_codec(self) -> PositionCodec:
+        return self._position_codec
 
     def _create_text_document(
         self,
@@ -78,7 +88,7 @@ class Workspace(object):
             version=version,
             language_id=language_id,
             sync_kind=self._sync_kind,
-            position_encoding=self._position_encoding,
+            position_codec=self._position_codec,
         )
 
     def add_folder(self, folder: WorkspaceFolder):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -19,7 +19,7 @@
 import re
 
 from lsprotocol import types
-from pygls.workspace import TextDocument, Position
+from pygls.workspace import TextDocument, PositionCodec
 from .conftest import DOC, DOC_URI
 
 
@@ -174,71 +174,71 @@ def test_document_source_unicode():
 
 
 def test_position_from_utf16():
-    position = Position(encoding=types.PositionEncodingKind.Utf16)
-    assert position.position_from_client_units(
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
+    assert codec.position_from_client_units(
         ['x="😋"'], types.Position(line=0, character=3)
     ) == types.Position(line=0, character=3)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         ['x="😋"'], types.Position(line=0, character=5)
     ) == types.Position(line=0, character=4)
 
 
 def test_position_from_utf32():
-    position = Position(encoding=types.PositionEncodingKind.Utf32)
-    assert position.position_from_client_units(
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf32)
+    assert codec.position_from_client_units(
         ['x="😋"'], types.Position(line=0, character=3)
     ) == types.Position(line=0, character=3)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         ['x="😋"'], types.Position(line=0, character=4)
     ) == types.Position(line=0, character=4)
 
 
 def test_position_from_utf8():
-    position = Position(encoding=types.PositionEncodingKind.Utf8)
-    assert position.position_from_client_units(
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf8)
+    assert codec.position_from_client_units(
         ['x="😋"'], types.Position(line=0, character=3)
     ) == types.Position(line=0, character=3)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         ['x="😋"'], types.Position(line=0, character=7)
     ) == types.Position(line=0, character=4)
 
 
 def test_position_to_utf16():
-    position = Position(encoding=types.PositionEncodingKind.Utf16)
-    assert position.position_to_client_units(
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
+    assert codec.position_to_client_units(
         ['x="😋"'], types.Position(line=0, character=3)
     ) == types.Position(line=0, character=3)
 
-    assert position.position_to_client_units(
+    assert codec.position_to_client_units(
         ['x="😋"'], types.Position(line=0, character=4)
     ) == types.Position(line=0, character=5)
 
 
 def test_position_to_utf32():
-    position = Position(encoding=types.PositionEncodingKind.Utf32)
-    assert position.position_to_client_units(
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf32)
+    assert codec.position_to_client_units(
         ['x="😋"'], types.Position(line=0, character=3)
     ) == types.Position(line=0, character=3)
 
-    assert position.position_to_client_units(
+    assert codec.position_to_client_units(
         ['x="😋"'], types.Position(line=0, character=4)
     ) == types.Position(line=0, character=4)
 
 
 def test_position_to_utf8():
-    position = Position(encoding=types.PositionEncodingKind.Utf8)
-    assert position.position_to_client_units(
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf8)
+    assert codec.position_to_client_units(
         ['x="😋"'], types.Position(line=0, character=3)
     ) == types.Position(line=0, character=3)
 
-    assert position.position_to_client_units(
+    assert codec.position_to_client_units(
         ['x="😋"'], types.Position(line=0, character=4)
     ) == types.Position(line=0, character=6)
 
 
 def test_range_from_utf16():
-    position = Position(encoding=types.PositionEncodingKind.Utf16)
-    assert position.range_from_client_units(
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
+    assert codec.range_from_client_units(
         ['x="😋"'],
         types.Range(
             start=types.Position(line=0, character=3),
@@ -253,7 +253,7 @@ def test_range_from_utf16():
         start=types.Position(line=0, character=3),
         end=types.Position(line=0, character=5),
     )
-    actual = position.range_from_client_units(['x="😋😋"'], range)
+    actual = codec.range_from_client_units(['x="😋😋"'], range)
     expected = types.Range(
         start=types.Position(line=0, character=3),
         end=types.Position(line=0, character=4),
@@ -262,8 +262,8 @@ def test_range_from_utf16():
 
 
 def test_range_to_utf16():
-    position = Position(encoding=types.PositionEncodingKind.Utf16)
-    assert position.range_to_client_units(
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
+    assert codec.range_to_client_units(
         ['x="😋"'],
         types.Range(
             start=types.Position(line=0, character=3),
@@ -278,7 +278,7 @@ def test_range_to_utf16():
         start=types.Position(line=0, character=3),
         end=types.Position(line=0, character=4),
     )
-    actual = position.range_to_client_units(['x="😋😋"'], range)
+    actual = codec.range_to_client_units(['x="😋😋"'], range)
     expected = types.Range(
         start=types.Position(line=0, character=3),
         end=types.Position(line=0, character=5),
@@ -300,56 +300,64 @@ def test_offset_at_position_utf16():
 
 
 def test_offset_at_position_utf32():
-    doc = TextDocument(DOC_URI, DOC, position_encoding=types.PositionEncodingKind.Utf32)
+    doc = TextDocument(
+        DOC_URI,
+        DOC,
+        position_codec=PositionCodec(encoding=types.PositionEncodingKind.Utf32),
+    )
     assert doc.offset_at_position(types.Position(line=0, character=8)) == 8
     assert doc.offset_at_position(types.Position(line=5, character=0)) == 39
 
 
 def test_offset_at_position_utf8():
-    doc = TextDocument(DOC_URI, DOC, position_encoding=types.PositionEncodingKind.Utf8)
+    doc = TextDocument(
+        DOC_URI,
+        DOC,
+        position_codec=PositionCodec(encoding=types.PositionEncodingKind.Utf8),
+    )
     assert doc.offset_at_position(types.Position(line=0, character=8)) == 8
     assert doc.offset_at_position(types.Position(line=5, character=0)) == 41
 
 
 def test_utf16_to_utf32_position_cast():
-    position = Position(encoding=types.PositionEncodingKind.Utf16)
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
     lines = ["", "😋😋", ""]
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=0, character=0)
     ) == types.Position(line=0, character=0)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=0, character=1)
     ) == types.Position(line=0, character=0)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=1, character=0)
     ) == types.Position(line=1, character=0)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=1, character=2)
     ) == types.Position(line=1, character=1)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=1, character=3)
     ) == types.Position(line=1, character=2)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=1, character=4)
     ) == types.Position(line=1, character=2)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=1, character=100)
     ) == types.Position(line=1, character=2)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=3, character=0)
     ) == types.Position(line=2, character=0)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=4, character=10)
     ) == types.Position(line=2, character=0)
 
 
 def test_position_for_line_endings():
-    position = Position(encoding=types.PositionEncodingKind.Utf16)
+    codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
     lines = ["x\r\n", "y\n"]
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=0, character=10)
     ) == types.Position(line=0, character=1)
-    assert position.position_from_client_units(
+    assert codec.position_from_client_units(
         lines, types.Position(line=1, character=10)
     ) == types.Position(line=1, character=1)
 


### PR DESCRIPTION
## Description

Implement the refactoring discussed in #382

- Rename pygls `Position` type to `PositionCodec`
- Create a single `PositionCodec` instance in `Workspace` that is used by all `TextDocument` instances
- Add `position_encoding` and `position_codec` read-only properties to `Workspace`
- Make `position_codec` a read-only property of `TextDocument`
- Improve deprecation warning messages associated with the old position mapping functions that have been replaced by `PositionCodec`

Resolves #382

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://conventionalcommits.org/
