### PR TITLE
chore: fix use of deprecated methods in tests/test_language_server.py

### DIFF
--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -82,9 +82,9 @@ def test_bf_text_document_did_open(client_server):
 
     sleep(1)
 
-    assert len(server.lsp.workspace.documents) == 1
+    assert len(server.lsp.workspace.text_documents) == 1
 
-    document = server.workspace.get_document(__file__)
+    document = server.workspace.get_text_document(__file__)
     assert document.uri == __file__
     assert document.version == 1
     assert document.source == "test"


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Fixes the following two DeprecationWarnings:

```
tests/test_language_server.py::test_bf_text_document_did_open
  C:\_\pygls\tests\test_language_server.py:85: DeprecationWarning: 'workspace.documents' has been deprecated, use 'workspace.text_documents' instead
    assert len(server.lsp.workspace.documents) == 1

tests/test_language_server.py::test_bf_text_document_did_open
  C:\_\pygls\tests\test_language_server.py:87: DeprecationWarning: 'workspace.get_document' has been deprecated, use 'workspace.get_text_document' instead
    document = server.workspace.get_document(__file__)
```

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://conventionalcommits.org/
