### PR TITLE
docs: correct doc comment for PositionCodec.client_num_units

### DIFF
--- a/pygls/workspace/position_codec.py
+++ b/pygls/workspace/position_codec.py
@@ -49,10 +49,10 @@ class PositionCodec:
 
     def client_num_units(self, chars: str):
         """
-        Calculate the length of `str` in utf-16 code units.
+        Calculate the length of `str` in client-supported UTF-[32|16|8] code units.
 
         Arguments:
-            chars (str): The string to return the length in utf-16 code units for.
+            chars (str): The string to return the length in UTF-[32|16|8] code units for.
         """
         utf32_units = len(chars)
         if self.encoding == types.PositionEncodingKind.Utf32:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Fixes an incorrect doc comment that was a hangover from the old utf-16 only Position implementation.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://conventionalcommits.org/
