### PR TITLE
build: v1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygls"
-version = "1.1.1"
+version = "1.1.2"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 authors = ["Open Law Library <info@openlawlib.org>"]
 maintainers = [


### PR DESCRIPTION
This release will include the following PRs:

* chore: split protocol.py into own folder/files by @tombh in https://github.com/openlawlibrary/pygls/pull/398
* docs: correct doc comment for PositionCodec.client_num_units by @RossBencina in https://github.com/openlawlibrary/pygls/pull/399
* build(deps-dev): bump urllib3 from 2.0.6 to 2.0.7 by @dependabot in https://github.com/openlawlibrary/pygls/pull/401
* build: allow installation with typeguard 4.x  by @zanieb in https://github.com/openlawlibrary/pygls/pull/405
