### PR TITLE
build: v1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygls"
-version = "1.1.2"
+version = "1.2.0"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 authors = ["Open Law Library <info@openlawlib.org>"]
 maintainers = [


### PR DESCRIPTION
* Remove dependency on `typeguard` by @karthiknadig in https://github.com/openlawlibrary/pygls/pull/411
* Simplify vscode-playground setup and fix Python discovery by @alcarney in https://github.com/openlawlibrary/pygls/pull/374
* chore: pin lsprotocol to 2023.0.0 by @alcarney in https://github.com/openlawlibrary/pygls/pull/414
