### PR TITLE
handle ResponseErrors correctly

### DIFF
--- a/pygls/exceptions.py
+++ b/pygls/exceptions.py
@@ -19,6 +19,7 @@
 import traceback
 from typing import Set
 from typing import Type
+from lsprotocol.types import ResponseError
 
 
 class JsonRpcException(Exception):
@@ -56,14 +57,8 @@ class JsonRpcException(Exception):
         # Defaults to UnknownErrorCode
         return getattr(cls, "CODE", -32001) == code
 
-    def to_dict(self):
-        exception_dict = {
-            "code": self.code,
-            "message": self.message,
-        }
-        if self.data is not None:
-            exception_dict["data"] = str(self.data)
-        return exception_dict
+    def to_response_error(self) -> ResponseError:
+        return ResponseError(code=self.code, message=self.message, data=self.data)
 
 
 class JsonRpcInternalError(JsonRpcException):


### PR DESCRIPTION
The error on a `ResponseErrorMessage` is supposed to be a `ResponseError`, not a dictionary.

Older versions of cattrs seem to have tolerated the mistake, but newer ones don't.  

The reason that this repository's own tests don't find this is that it continues to support python 3.7: and the versions of cattrs that don't like the mistake have dropped support for python 3.7.  So `poetry update` here does not get the bug-exposing update.

However users who are on recent python versions do get the update, and do experience errors eg see https://github.com/pappasam/jedi-language-server/issues/296

A couple of meta-comments on this issue:
- probably it's time to drop support for python 3.7 here: much of the world has already done so, and by continuing to support it pygls is not seeing updates that its users are seeing
- it's another example where adding type annotations would have caught the bug before it ever happened