### PR TITLE
cattrs is a direct dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1274,4 +1274,4 @@ ws = ["websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "24c73f352815a40a121eb14a93183b1b257d33ea4cfc92908eaa303d62d36d92"
+content-hash = "5cda6a52481cb05274ed06efec69ffe66392bd08dbea32f3fe22d28609484af8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 # See https://github.com/MousaZeidBaker/poetry-plugin-up
 [tool.poetry.dependencies]
 python = ">=3.8"
+cattrs = ">=23.1.2"
 lsprotocol = "2023.0.0"
 websockets = { version = ">=11.0.3", optional = true }
 


### PR DESCRIPTION
`cattrs` is imported as a direct dependency in several places, so this project should declare that dependency.

`cattrs` uses calendar versioning so there's no reason to expect that any choice of upper bound will be safe.  I've guessed that you'll nevertheless prefer no upper bound over a pin, that seems to be the direction of travel in other issues and discussions.