### PR TITLE
Add support for debugging servers in the VSCode Playground

### DIFF
--- a/examples/servers/.vscode/launch.json
+++ b/examples/servers/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "configurations": [
+        {
+            "name": "pygls: Debug Server",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "${config:pygls.server.debugHost}",
+                "port": "${config:pygls.server.debugPort}"
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ],
+            "justMyCode": false
+        }
+    ]
+}

--- a/examples/servers/.vscode/settings.json
+++ b/examples/servers/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
     // Uncomment to override Python interpreter used.
     // "pygls.server.pythonPath": "/path/to/python",
+    "pygls.server.debug": false,
+    // "pygls.server.debugHost": "localhost",
+    // "pygls.server.debugPort": 5678,
     "pygls.server.launchScript": "json_server.py",
     "pygls.trace.server": "off",
     "pygls.client.documentSelector": [

--- a/examples/vscode-playground/README.md
+++ b/examples/vscode-playground/README.md
@@ -75,3 +75,10 @@ The `code_actions.py` example is intended to be used with text files (e.g. the p
 ```
 
 You can find the full list of known language identifiers [here](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers).
+
+#### Debugging the server
+
+To debug the language server set the `pygls.server.debug` option to `true`.
+The server should be restarted and the debugger connect automatically.
+
+You can control the host and port that the debugger uses through the `pygls.server.debugHost` and `pygls.server.debugPort` options.

--- a/examples/vscode-playground/package.json
+++ b/examples/vscode-playground/package.json
@@ -54,6 +54,24 @@
             "description": "The working directory from which to launch the server.",
             "markdownDescription": "The working directory from which to launch the server.\nIf blank, this will default to the `examples/servers` directory."
           },
+          "pygls.server.debug": {
+            "scope": "resource",
+            "default": false,
+            "type": "boolean",
+            "description": "Enable debugging of the server process."
+          },
+          "pygls.server.debugHost": {
+            "scope": "resource",
+            "default": "localhost",
+            "type": "string",
+            "description": "The host on which the server process to debug is running."
+          },
+          "pygls.server.debugPort": {
+            "scope": "resource",
+            "default": 5678,
+            "type": "integer",
+            "description": "The port number on which the server process to debug is listening."
+          },
           "pygls.server.launchScript": {
             "scope": "resource",
             "type": "string",

--- a/examples/vscode-playground/package.json
+++ b/examples/vscode-playground/package.json
@@ -73,12 +73,14 @@
             "default": "off",
             "enum": [
               "off",
+              "messages",
               "verbose"
             ],
             "description": "Controls if LSP messages send to/from the server should be logged.",
             "enumDescriptions": [
               "do not log any lsp messages",
-              "log all lsp messages sent to/from the server"
+              "log all lsp messages sent to/from the server",
+              "log all lsp messages sent to/from the server, including their contents"
             ]
           }
         }


### PR DESCRIPTION
This adds back the ability for language servers to be debugged through the example VSCode extension.
Rather than make the user launch the client and server separately and using a TCP connection, the extension now uses the official Python extension to wrap the server in a debug adapter and automatically starts the debug session.

To debug the server set the `pygls.server.debug` option to `true`.

This will go towards #424 (though the docs will still need to be updated)

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://conventionalcommits.org/
