### PR TITLE
Release v1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygls"
-version = "1.2.1"
+version = "1.3.0"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 authors = ["Open Law Library <info@openlawlib.org>"]
 maintainers = [


### PR DESCRIPTION
The main change I think is bumping `lsprotocol` to [2023.0.1](https://github.com/microsoft/lsprotocol/releases/tag/2023.0.1)

All changes:

* ci: don't let Pyodide test fail the whole build by @tombh in https://github.com/openlawlibrary/pygls/pull/420
* feat: drop Python 3.7 support by @tombh in https://github.com/openlawlibrary/pygls/pull/417
* Do the tests really freeze? by @dimbleby in https://github.com/openlawlibrary/pygls/pull/422
* Add `pytest-lsp` and `lsp-devtools` to Implementations.md by @alcarney in https://github.com/openlawlibrary/pygls/pull/426
* Add support for debugging servers in the VSCode Playground by @alcarney in https://github.com/openlawlibrary/pygls/pull/425
* Update `lsprotocol` to 2023.0.1 by @karthiknadig in https://github.com/openlawlibrary/pygls/pull/432
