### PR TITLE
Typo: Apache License missing dash: Affects PyPI License Declaration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [
 ]
 repository = "https://github.com/openlawlibrary/pygls"
 documentation = "https://pygls.readthedocs.io/en/latest"
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 
 # You may want to use the Poetry "Up" plugin to automatically update all dependencies to


### PR DESCRIPTION
Poetry requires an EXACT match for the License name in order to auto-populate classifiers. Changed `Apache 2.0` to `Apache-2.0`

From version 1.1.0 forward, after switching to Poetry, PyPI has displayed the license as:
`License: Other/Proprietary License (Apache 2.0)`

PyPI **should** say: 
`License: Apache Software License (Apache 2.0)`

This is caused by the License not being an exact match to what Poetry is expecting.

This is a problem because within enterprise environments, packages are often scanned for security and legal risks. A proprietary, i.e., non-open license can be a legal issue, so it's important to have a proper license declaration to allow automated tools to make a proper evaluation.

Poetry code reference:
https://github.com/python-poetry/poetry-core/blob/219c52e6cb8b086c78f25bbfa1168d0a3096fb31/src/poetry/core/spdx/license.py#L29