### PR TITLE
Respect client's preferred encoding when possible

### DIFF
--- a/tests/test_feature_manager.py
+++ b/tests/test_feature_manager.py
@@ -240,6 +240,19 @@ def server_capabilities(**kwargs):
                     ]
                 )
             ),
+            server_capabilities(position_encoding=lsp.PositionEncodingKind.Utf8),
+        ),
+        (
+            lsp.INITIALIZE,
+            None,
+            lsp.ClientCapabilities(
+                general=lsp.GeneralClientCapabilities(
+                    position_encodings=[
+                        lsp.PositionEncodingKind.Utf32,
+                        lsp.PositionEncodingKind.Utf8,
+                    ]
+                )
+            ),
             server_capabilities(position_encoding=lsp.PositionEncodingKind.Utf32),
         ),
         (


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Related to #445 

This change would make `pygls` accept the client's preferred encoding rather than preferring `UTF-16` blindly. For editors that prefer `UTF-32` this is advantageous for `pygls` since the position encoding/decoding becomes simpler.

## Code review checklist (for code reviewer to complete)

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Commit messages are meaningful (see [this][commit messages] for details)
- [X] Tests have been included and/or updated, as appropriate
- [X] Docstrings have been included and/or updated, as appropriate
- [X] Standalone docs have been updated accordingly

[commit messages]: https://conventionalcommits.org/
