### PR TITLE
docs: add linter commander to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,12 @@ _Please replace this description with a concise description of this Pull Request
 - [ ] Docstrings have been included and/or updated, as appropriate
 - [ ] Standalone docs have been updated accordingly
 
+## Automated linters
+
+You can run the lints that are run on CI locally with:
+```sh
+poetry install --all-extras --with dev
+poetry run poe lint
+```
+
 [commit messages]: https://conventionalcommits.org/


### PR DESCRIPTION
I manually added the new lines into this very PR template in this comment...

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/
