### PR TITLE
ci: start testing against Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,10 @@ jobs:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -44,8 +45,12 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: '1.5.1'
+          version: '1.8.3'
           virtualenvs-in-project: true
+      - run: |
+          cat *.log
+        if: failure()
+
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v3

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,9 +41,6 @@ files = [
     {file = "babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"},
 ]
 
-[package.dependencies]
-pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
-
 [package.extras]
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
@@ -424,8 +421,11 @@ name = "docutils"
 version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
 optional = false
-python-versions = "*"
-files = []
+python-versions = ">=3.7"
+files = [
+    {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
+    {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
+]
 
 [[package]]
 name = "exceptiongroup"
@@ -915,17 +915,6 @@ pytest = ">=7.0.0,<9"
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
-
-[[package]]
-name = "pytz"
-version = "2024.1"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
-    {file = "pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"},
-]
 
 [[package]]
 name = "pyyaml"
@@ -1478,5 +1467,5 @@ ws = ["websockets"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8"
-content-hash = "c8f3463b1166ef47c5004f9a3f78acba5ffd2e3aaec38f87db83006946196995"
+python-versions = ">=3.9"
+content-hash = "1dde66e7780b345c31879a54f573c8c2ea813177df09f5e3610395e9c91c0976"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 # may be too restrictive.
 # See https://github.com/MousaZeidBaker/poetry-plugin-up
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 cattrs = ">=23.1.2"
 lsprotocol = "2024.0.0a2"
 websockets = { version = ">=11.0.3", optional = true }
@@ -29,7 +29,6 @@ ws = ["websockets"]
 [tool.poetry.group.dev.dependencies]
 # Replaces (amongst many other things) flake8 and bandit
 ruff = ">=0.1.6"
-# TODO `poethepoet>=0.20` needs python 3.8
 poethepoet = ">=0.24.4"
 mypy = ">=1.7.1"
 black = "^24.4.1"


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Python 3.13 will be [coming soon](https://dev.to/hugovk/help-test-python-313-14j1).
Opening this PR to see what, if any impact 3.13 has on pygls.

We might also want to consider the [free threaded version](https://dev.to/hugovk/help-us-test-free-threaded-python-without-the-gil-1hgf) at some point?

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/
