### PR TITLE
fix: return ``None`` for non ``file:`` URIs

### DIFF
--- a/docs/source/howto/migrate-to-v2.rst
+++ b/docs/source/howto/migrate-to-v2.rst
@@ -25,6 +25,11 @@ Python Support
 
 *pygls v2* removes support for Python 3.8 and adds support for Python 3.13 (with the GIL, you are welcome to try the free-threaded version just note that it has not been tested yet!)
 
+URI Handling
+------------
+
+The :func:`pygls.uris.to_fs_path` will now return ``None`` for URIs that do not have a ``file:`` scheme.
+
 
 Removed Deprecated Functions
 ----------------------------

--- a/docs/source/reference/uris.rst
+++ b/docs/source/reference/uris.rst
@@ -1,0 +1,16 @@
+URIs
+====
+
+.. currentmodule:: pygls.uris
+
+.. autofunction:: from_fs_path
+
+.. autofunction:: to_fs_path
+
+.. autofunction:: uri_scheme
+
+.. autofunction:: uri_with
+
+.. autofunction:: urlparse
+
+.. autofunction:: urlunparse

--- a/pygls/uris.py
+++ b/pygls/uris.py
@@ -21,6 +21,8 @@ A collection of URI utilities with logic built on the VSCode URI library.
 
 https://github.com/Microsoft/vscode-uri/blob/e59cab84f5df6265aed18ae5f43552d3eef13bb9/lib/index.ts
 """
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import re
@@ -75,20 +77,22 @@ def from_fs_path(path: str):
         return None
 
 
-def to_fs_path(uri: str):
+def to_fs_path(uri: str) -> str | None:
     """
     Returns the filesystem path of the given URI.
 
     Will handle UNC paths and normalize windows drive letters to lower-case.
     Also uses the platform specific path separator. Will *not* validate the
     path for invalid characters and semantics.
-    Will *not* look at the scheme of this URI.
     """
     try:
         # scheme://netloc/path;parameters?query#fragment
         scheme, netloc, path, _, _, _ = urlparse(uri)
 
-        if netloc and path and scheme == "file":
+        if scheme != "file":
+            return None
+
+        if netloc and path:
             # unc path: file://shares/c$/far/boo
             value = f"//{netloc}{path}"
 

--- a/pygls/workspace/workspace.py
+++ b/pygls/workspace/workspace.py
@@ -47,10 +47,7 @@ class Workspace(object):
         self._root_uri = root_uri
         if self._root_uri is not None:
             self._root_uri_scheme = uri_scheme(self._root_uri)
-            root_path = to_fs_path(self._root_uri)
-            if root_path is None:
-                raise Exception("Couldn't get `root_path` from `root_uri`")
-            self._root_path = root_path
+            self._root_path = to_fs_path(self._root_uri)
         else:
             self._root_path = None
         self._sync_kind = sync_kind
@@ -151,9 +148,14 @@ class Workspace(object):
         return self._text_documents.get(doc_uri) or self._create_text_document(doc_uri)
 
     def is_local(self):
-        return (
-            self._root_uri_scheme == "" or self._root_uri_scheme == "file"
-        ) and os.path.exists(self._root_path)
+
+        if self._root_uri_scheme not in {"", "file"}:
+            return False
+
+        if (path := self._root_path) is None:
+            return False
+
+        return os.path.exists(path)
 
     def put_notebook_document(self, params: types.DidOpenNotebookDocumentParams):
         notebook = params.notebook_document


### PR DESCRIPTION
As discussed in #209 this tweaks the `to_fs_path` function to return ``None`` when passed a URI that does not have a `file:` scheme.

This does have a few knock-on effects, but if anything it's going to highlight places where `pygls` makes some incorrect assumptions

Closes #209

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/