### PR TITLE
Migrate `JsonRPCServer.start_tcp` and `JsonRPCServer.start_ws` to high level asyncio APIs

### DIFF
--- a/docs/source/howto/migrate-to-v2.rst
+++ b/docs/source/howto/migrate-to-v2.rst
@@ -399,9 +399,22 @@ If you need to access the underlying protocol object this is now via the ``proto
 
 pygls' base server class has been renamed
 
+Removed ``loop`` argument from ``pygls.server.JsonRPCServer``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Servers and clients in pygls v2 now both use the high level asyncio API, removing the need for an explicit ``loop`` argument to be passed in.
+If you need control over the event loop used by pygls you can use functions like :external:py:function:`asyncio.set_event_loop` before starting the server/client.
+
 Removed ``multiprocessing.pool.ThreadPool``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :external:py:class:`multiprocessing.pool.ThreadPool` instance has been removed, *pygls* now makes use of :external:py:class:`concurrent.futures.ThreadPoolExecutor` for all threaded tasks.
 
 The ``thread_pool_executor`` attribute of the base ``JsonRPCServer`` class has been removed, the ``ThreadPoolExecutor`` can be accessed via the ``thread_pool`` attribute instead.
+
+New ``pygls.io_`` module
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+There is a new ``pygls.io_`` module containing main message parsing loop code common to both client and server
+
+- The equivlaent to pygls v1's ``pygls.server.aio_readline`` function is now ``pygls.io_.run_async``

--- a/pygls/protocol/json_rpc.py
+++ b/pygls/protocol/json_rpc.py
@@ -15,29 +15,29 @@
 # limitations under the License.                                           #
 ############################################################################
 from __future__ import annotations
+
 import asyncio
 import enum
 import json
 import logging
 import re
 import sys
-import uuid
 import traceback
+import uuid
 from concurrent.futures import Future
 from functools import partial
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     List,
     Optional,
     Type,
     Union,
-    TYPE_CHECKING,
 )
 
 import attrs
 from cattrs.errors import ClassValidationError
-
 from lsprotocol.types import (
     CANCEL_REQUEST,
     EXIT,
@@ -47,19 +47,21 @@ from lsprotocol.types import (
 )
 
 from pygls.exceptions import (
+    FeatureNotificationError,
+    FeatureRequestError,
     JsonRpcException,
     JsonRpcInternalError,
     JsonRpcInvalidParams,
     JsonRpcMethodNotFound,
     JsonRpcRequestCancelled,
-    FeatureNotificationError,
-    FeatureRequestError,
 )
 from pygls.feature_manager import FeatureManager, is_thread_function
 
 if TYPE_CHECKING:
     from cattrs import Converter
-    from pygls.server import JsonRPCServer, WebSocketTransportAdapter
+
+    from pygls.io_ import WebSocketTransportAdapter
+    from pygls.server import JsonRPCServer
 
 
 logger = logging.getLogger(__name__)

--- a/pygls/protocol/language_server.py
+++ b/pygls/protocol/language_server.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 import typing
 from functools import lru_cache
 from itertools import zip_longest
@@ -116,8 +115,6 @@ class LanguageServerProtocol(JsonRPCProtocol, metaclass=LSPMeta):
         """Stops the server process."""
         if self.transport is not None:
             self.transport.close()
-
-        sys.exit(0 if self._shutdown else 1)
 
     @lsp_method(types.INITIALIZE)
     def lsp_initialize(self, params: types.InitializeParams) -> types.InitializeResult:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,15 @@ def transport(request):
     return request.config.getoption("lsp_transport")
 
 
+@pytest.hookimpl(tryfirst=True)
+def pytest_report_header(config: pytest.Config):
+    """Report the above settings in pytest's output"""
+    runtime = config.getoption("lsp_runtime")
+    transport = config.getoption("lsp_transport")
+
+    return [f"pygls: {runtime=}, {transport=}"]
+
+
 @pytest.fixture(scope="session")
 def path_for():
     """Returns the path corresponding to a file in the example workspace"""

--- a/tests/ls_setup.py
+++ b/tests/ls_setup.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and      #
 # limitations under the License.                                           #
 ############################################################################
-import asyncio
 import json
 import os
 import threading
@@ -27,12 +26,11 @@ from lsprotocol.types import (
     ClientCapabilities,
     InitializeParams,
 )
-from pygls.lsp.server import LanguageServer
 
+from pygls.lsp.server import LanguageServer
 
 from . import CMD_ASYNC, CMD_SYNC, CMD_THREAD
 from ._init_server_stall_fix_hack import retry_stalled_init_fix_hack
-
 
 CALL_TIMEOUT = 3
 
@@ -121,7 +119,7 @@ class NativeClientServer:
         self.server_thread.daemon = True
 
         # Setup client
-        self.client = LS("client", "v1", asyncio.new_event_loop())
+        self.client = LS("client", "v1")
         self.client_thread = threading.Thread(
             name="Client Thread",
             target=self.client.start_io,
@@ -145,10 +143,7 @@ class NativeClientServer:
         self.client.protocol.notify(EXIT)
         self.server_thread.join()
         self.client._stop_event.set()
-        try:
-            self.client.loop._signal_handlers.clear()  # HACK ?
-        except AttributeError:
-            pass
+
         self.client_thread.join()
 
     @retry_stalled_init_fix_hack()


### PR DESCRIPTION
This PR completes the migration of the server-side of pygls to the higher level asyncio APIs
Closes #334 

**start_tcp**

- Since `asyncio.start_server` gives us a reader, writer pair it's enough to reuse the `run_async` method from the `pygls.io_` module.

**start_ws**

- This moves the `WebSocketTransportAdapter` into `pygls.io_` and a new `run_websocket` function, allowing the websocket main loop to be shared between client and server code
- This PR also takes the opportunity to migrate to the new `websockets.asyncio` API

It's also worth noting that the test suite now includes the values of `--lsp-runtime` and `--lsp-transport` in the header pytest prints at the start of a test run

```
$ pytest
=========================================== test session starts ===========================================
platform linux -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /var/home/alex/Projects/openlawlibrary/pygls/main
configfile: pyproject.toml
plugins: cov-5.0.0, asyncio-0.24.0
asyncio: mode=Mode.AUTO, default_loop_scope=None
pygls: runtime='cpython', transport='stdio'         <-- NEW!
collected 222 items                                                                                                

```

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/
