### PR TITLE
fix: fallback JsonRpcException code for malformed server errors

### DIFF
--- a/pygls/exceptions.py
+++ b/pygls/exceptions.py
@@ -29,7 +29,7 @@ class JsonRpcException(Exception):
         message = message or getattr(self.__class__, "MESSAGE")
         super().__init__(message)
         self.message = message
-        self.code = code or getattr(self.__class__, "CODE")
+        self.code = code or getattr(self.__class__, "CODE", -32603)
         self.data = data
 
     def __eq__(self, other):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Some LSP server implementations, do not reliably implement error handling. For instance, `gopls` may throw errors without a code when receiving malformed `textDocument/references` requests that contain invalid position data.

This behavior can cause a blocking loop in the message queue, which the user of the `pygls` library cannot catch because it occurs outside their event loop.

This patch introduces a fallback default error code in the jrpc client, ensuring that such errors propagate correctly to the user's event loop. As a result, `pygls` users can catch and handle these errors properly.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/
