### PR TITLE
Update the hello world example to the v2.0 syntax

### DIFF
--- a/examples/hello-world/main.py
+++ b/examples/hello-world/main.py
@@ -9,7 +9,7 @@ server = LanguageServer("example-server", "v0.1")
     types.CompletionOptions(trigger_characters=["."]),
 )
 def completions(params: types.CompletionParams):
-    document = server.workspace.get_document(params.text_document.uri)
+    document = server.workspace.get_text_document(params.text_document.uri)
     current_line = document.lines[params.position.line].strip()
 
     if not current_line.endswith("hello."):


### PR DESCRIPTION
## Description 

The v2.0 introduce some syntax breaking changes. When I tried running the included `hello-world` example, it broke. I had to update the syntax to get it working.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly


[commit messages]: https://conventionalcommits.org/
