### PR TITLE
cache document.lines after first use

### DIFF
--- a/pygls/workspace/text_document.py
+++ b/pygls/workspace/text_document.py
@@ -58,6 +58,7 @@ class TextDocument(object):
 
         self._local = local
         self._source = source
+        self._lines = None
 
         self._is_sync_kind_full = sync_kind == types.TextDocumentSyncKind.Full
         self._is_sync_kind_incremental = (
@@ -164,7 +165,10 @@ class TextDocument(object):
 
     @property
     def lines(self) -> List[str]:
-        return self.source.splitlines(True)
+        if self._lines is None:
+            self._lines = self.source.splitlines(True)
+
+        return self._lines
 
     def offset_at_position(self, client_position: types.Position) -> int:
         """Return the character offset pointed at by the given client_position."""


### PR DESCRIPTION
## Description

Refer to [this](https://github.com/openlawlibrary/pygls/issues/538) for more info, but basically everytime `document.lines` is called, it recomputes `document.source.split()`, and I wanted to cache it to avoid the recomputation.

This is a simple in-memory cache.

I am new to this project so I'm not aware of the full life cycle of `document.source`. If it is loaded into memory only once on class instantiation and never changes (which I think is the case), then this simple in-memory cache should work. But we should allow `document.source` to be altered and modified dynamically, then this approach is ineffective since the cache won't know when it should be invalidated.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/
