### PR TITLE
Fix pyodide tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -14,23 +14,23 @@ files = [
 
 [[package]]
 name = "attrs"
-version = "24.2.0"
+version = "25.3.0"
 description = "Classes Without Boilerplate"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
-    {file = "attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346"},
+    {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
+    {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
 ]
 
 [package.extras]
-benchmark = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\"", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\"", "pytest-xdist[psutil]"]
-cov = ["cloudpickle ; platform_python_implementation == \"CPython\"", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\"", "pytest-xdist[psutil]"]
-dev = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\"", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\"", "pytest-xdist[psutil]"]
-docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\"", "pytest-xdist[psutil]"]
-tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\""]
+benchmark = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
+cov = ["cloudpickle ; platform_python_implementation == \"CPython\"", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
+dev = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pre-commit-uv", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
+docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier"]
+tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
+tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
 name = "babel"
@@ -1356,4 +1356,4 @@ ws = ["websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "615e8a754960ff90cb117fe83039a7be1ba28c5d9fcdaf784e65f478acca0890"
+content-hash = "42407fd7302e32b853ad0ed033dbcbeee62d0ad55cdc080ee159e77b82705fde"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 # See https://github.com/MousaZeidBaker/poetry-plugin-up
 [tool.poetry.dependencies]
 python = ">=3.9"
+attrs = ">=24.3.0"
 cattrs = ">=23.1.2"
 lsprotocol = "2025.0.0rc1"
 websockets = { version = ">=13.0", optional = true }

--- a/tests/pyodide/package-lock.json
+++ b/tests/pyodide/package-lock.json
@@ -8,13 +8,13 @@
             "name": "pyodide_tests",
             "version": "0.0.0",
             "dependencies": {
-                "pyodide": "^0.26"
+                "pyodide": "^0.27"
             }
         },
         "node_modules/pyodide": {
-            "version": "0.26.3",
-            "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.26.3.tgz",
-            "integrity": "sha512-cRe9CswiTNTIypOr/RtTb+aR8SxA6KG8aEf3i0OK0nzINLzF4jfVpV5DK2BwP3808ipxoL+ZrnUIjwN5wC8tCw==",
+            "version": "0.27.6",
+            "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.27.6.tgz",
+            "integrity": "sha512-ahiSHHs6iFKl2f8aO1wALINAlMNDLAtb44xCI87GQyH2tLDk8F8VWip3u1ZNIyglGSCYAOSFzWKwS1f9gBFVdg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "ws": "^8.5.0"

--- a/tests/pyodide/package.json
+++ b/tests/pyodide/package.json
@@ -5,6 +5,6 @@
     "main": "run_server.js",
     "author": "openlawlibrary",
     "dependencies": {
-        "pyodide": "^0.26"
+        "pyodide": "^0.27"
     }
 }


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This PR should fix the pyodide test suite - as well as bumping the version of pyodide we test to the latest.

The issue came down to dependency resolution... (something that I think has bitten us before?). The version of `attrs` available [by default](https://github.com/pyodide/pyodide/blob/28fcc1bf138732e62e7bbc926ea70a0f13149f54/packages/attrs/meta.yaml#L3) in pyodide was too old relative to the version of `cattrs` being selected by `micropip`.

(`cattrs` was attempting to import `attrs.NothingType` which was only introduced in `attrs v24.3.0`) 

I would have assumed that the [version bound](https://github.com/python-attrs/cattrs/commit/d987382fba782fbe3fea012575cc3c8afbe45481#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R43) on `attrs` supplied by `cattrs` itself would have been taken into account when installing `pygls` under pyodide but that does not seem to be the case.

So instead, I have added an explicit dependency on `attrs` to pygls itself, with a minimum version bound that ensures `attrs.NothingType` is always available

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/
