### PR TITLE
chore: add devcontainer definition and Makefile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+COPY tools.mk /
+
+RUN su vscode -c "make -f tools.mk tools" \
+    && rm tools.mk

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+    "name": "pygls",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "build": {
+	"dockerfile": "Dockerfile"
+    },
+    "containerEnv": {
+	"TZ": "UTC"
+    },
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "uname -a",
+    // Configure tool-specific properties.
+    "customizations": {
+	"vscode": {
+	    "extensions": [
+		"charliermarsh.ruff",
+		"ms-python.python",
+	    ]
+	}
+
+    }
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.devcontainer/tools.mk
+++ b/.devcontainer/tools.mk
@@ -1,0 +1,140 @@
+ARCH ?= $(shell arch)
+BIN ?= $(HOME)/.local/bin
+
+ifeq ($(strip $(ARCH)),)
+$(error Unable to determine platform architecture)
+endif
+
+NODE_VERSION := 20.19.2
+UV_VERSION := 0.7.9
+
+UV ?= $(shell command -v uv)
+UVX ?= $(shell command -v uvx)
+
+ifeq ($(strip $(UV)),)
+
+UV := $(BIN)/uv
+UVX := $(BIN)/uvx
+
+$(UV):
+	curl -L --output /tmp/uv.tar.gz https://github.com/astral-sh/uv/releases/download/$(UV_VERSION)/uv-$(ARCH)-unknown-linux-gnu.tar.gz
+	tar -xf /tmp/uv.tar.gz -C /tmp
+	rm /tmp/uv.tar.gz
+
+	test -d $(BIN) || mkdir -p $(BIN)
+
+	mv /tmp/uv-$(ARCH)-unknown-linux-gnu/uv $@
+	mv /tmp/uv-$(ARCH)-unknown-linux-gnu/uvx $(UVX)
+
+	$@ --version
+	$(UVX) --version
+
+endif
+
+# The versions of Python we support
+PYXX_versions := 3.10 3.11 3.12 3.13 3.14
+
+# Our default Python version
+PY_VERSION := 3.13
+
+# This effectively defines a function `PYXX` that takes a Python version number
+# (e.g. 3.8) and expands it out into a common block of code that will ensure a
+# verison of that interpreter is available to be used.
+#
+# This is perhaps a bit more complicated than I'd like, but it should mean that
+# the project's makefiles are useful both inside and outside of a devcontainer.
+#
+# `PYXX` has the following behavior:
+# - If possible, it will reuse the user's existing version of Python
+#   i.e. $(shell command -v pythonX.X)
+#
+# - The user may force a specific interpreter to be used by setting the
+#   variable when running make e.g. PYXX=/path/to/pythonX.X make ...
+#
+# - Otherwise, `make` will use `$(UV)` to install the given version of
+#   Python under `$(BIN)`
+#
+# See: https://www.gnu.org/software/make/manual/html_node/Eval-Function.html
+define PYXX =
+
+PY$(subst .,,$1) ?= $$(shell command -v python$1)
+
+ifeq ($$(strip $$(PY$(subst .,,$1))),)
+
+PY$(subst .,,$1) := $$(BIN)/python$1
+
+$$(PY$(subst .,,$1)): | $$(UV)
+	$$(UV) python find $1 || $$(UV) python install $1
+	ln -s $$$$($$(UV) python find $1) $$@
+
+	$$@ --version
+
+endif
+
+endef
+
+# Uncomment the following line to see what this expands into.
+#$(foreach version,$(PYXX_versions),$(info $(call PYXX,$(version))))
+$(foreach version,$(PYXX_versions),$(eval $(call PYXX,$(version))))
+
+POETRY ?= $(shell command -v poetry)
+
+ifeq ($(strip $(POETRY)),)
+
+POETRY := $(BIN)/poetry
+
+$(POETRY): | $(UV)
+	$(UV) tool install poetry
+	$@ --version
+
+endif
+
+
+PY_TOOLS := $(POETRY)
+
+# Set a default `python` command if there is not one already
+PY ?= $(shell command -v python)
+
+ifeq ($(strip $(PY)),)
+PY := $(BIN)/python
+
+$(PY): | $(UV)
+	$(UV) python install $(PY_VERSION)
+	ln -s $$($(UV) python find $(PY_VERSION)) $@
+	$@ --version
+endif
+
+# Node JS
+NPM ?= $(shell command -v npm)
+NPX ?= $(shell command -v npx)
+
+ifeq ($(strip $(NPM)),)
+
+NPM := $(BIN)/npm
+NPX := $(BIN)/npx
+NODE := $(BIN)/node
+NODE_DIR := $(HOME)/.local/node
+
+$(NPM):
+	curl -L --output /tmp/node.tar.xz https://nodejs.org/dist/v$(NODE_VERSION)/node-v$(NODE_VERSION)-linux-x64.tar.xz
+	tar -xJf /tmp/node.tar.xz -C /tmp
+	rm /tmp/node.tar.xz
+
+	[ -d $(NODE_DIR) ] || mkdir -p $(NODE_DIR)
+	mv /tmp/node-v$(NODE_VERSION)-linux-x64/* $(NODE_DIR)
+
+	[ -d $(BIN) ] || mkdir -p $(BIN)
+	ln -s $(NODE_DIR)/bin/node $(NODE)
+	ln -s $(NODE_DIR)/bin/npm $(NPM)
+	ln -s $(NODE_DIR)/bin/npx $(NPX)
+
+	$(NODE) --version
+	PATH=$(BIN) $(NPM) --version
+	PATH=$(BIN) $(NPX) --version
+
+endif
+
+# One command to bootstrap all tools and check their versions
+.PHONY: tools
+tools: $(UV) $(PY) $(PY_TOOLS) $(NPM) $(NPX)
+	for prog in $^ ; do echo -n "$${prog}\t" ; PATH=$(BIN) $${prog} --version; done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: dist
+dist: | $(POETRY)
+	$(POETRY) install --all-extras
+	git describe --tags --abbrev=0
+	$(POETRY) build
+
+.PHONY: lint
+lint: | $(POETRY)
+	$(POETRY) install --all-extras --with dev
+	$(POETRY) run poe lint
+
+.PHONY: test
+test: | $(POETRY)
+	$(POETRY) install --all-extras
+	$(POETRY) run poe test
+
+.PHONY: test-pyodide
+test-pyodide: dist | $(NPM) $(POETRY)
+	$(POETRY) install --with test
+	cd tests/pyodide && $(NPM) ci
+	$(POETRY) run poe test-pyodide
+
+.PHONY: pygls-playground
+pygls-playground: | $(NPM) $(POETRY)
+	$(POETRY) install --all-extras
+	cd .vscode/extensions/pygls-playground && $(NPM) install --no-save
+	cd .vscode/extensions/pygls-playground && $(NPM) run compile
+
+include .devcontainer/tools.mk


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Feel free to close this, but I am wondering if we'd be interested in adding a [devcontainer](https://containers.dev/) definition and some Makefile rules to the repo?

`pygls` is "just" a normal, pure Python library and so has fairly minimal requirements in terms of a development environment. But throw in the `pygls-playground` extension, pyodide test suite (and hopefully soon<sup>TM</sup>, a wasm-wasi test suite) and the list of requirements quickly starts to grow.

The provided `Makefile` aims to take you from a clean git clone to up and running in just a couple of commands. The only prerequisites being git, make, curl and a few other standard unix tools.

Some notes on the overall approach

- The devcontainer is **entirely optional**, it is there for people who like that approach and provides a known baseline against which the `Makefile` rules will just work<sup>TM</sup>.
- The `Makefile` *should* work fine outside of a container also (I use it this way 90% of the time), assuming you aren't running anything too exotic
- When bootstrapping a tool, the `Makefile` takes the following approach, (using poetry as an example)
  - If `poetry` is already available, the `Makefile` will use it
    ```make
    POETRY ?= $(shell command -v poetry)
    ```
  - Only if it can't be found will the `Makefile` attempt to install it
    ```make
    ifeq ($(strip $(POETRY)),)

    POETRY := $(BIN)/poetry

    $(POETRY): | $(UV)
	    $(UV) tool install poetry
	    $@ --version
    endif
    ```
    where `BIN = $HOME/.local/bin`

The initial version provides the following top-level targets

- `dist`: Package pygls as wheel and sdist
- `lint`: Run the lints we run in CI
- `test`: Run all tests under CPython, over stdio, tcp & websockets
- `test-pyodide`: Run the pyodide test suite
- `pygls-playground`: Setup and compile the pygls-playground extension

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/
