### PR TITLE
Make `TextDocument.lines` be a `Sequence[str]` rather than `List[str]`

### DIFF
--- a/pygls/workspace/position_codec.py
+++ b/pygls/workspace/position_codec.py
@@ -17,10 +17,9 @@
 # limitations under the License.                                           #
 ############################################################################
 import logging
-from typing import List, Optional, Union
+from typing import Optional, Union, Sequence
 
 from lsprotocol import types
-
 
 log = logging.getLogger(__name__)
 
@@ -64,7 +63,7 @@ class PositionCodec:
         return utf32_units + self.utf16_unit_offset(chars)
 
     def position_from_client_units(
-        self, lines: List[str], position: types.Position
+        self, lines: Sequence[str], position: types.Position
     ) -> types.Position:
         """
         Convert the position.character from UTF-[32|16|8] code units to UTF-32.
@@ -84,7 +83,7 @@ class PositionCodec:
         see: https://github.com/microsoft/language-server-protocol/issues/376
 
         Arguments:
-            lines (list):
+            lines (sequence):
                 The content of the document which the position refers to.
             position (Position):
                 The line and character offset in UTF-[32|16|8] code units.
@@ -138,14 +137,14 @@ class PositionCodec:
         return position
 
     def position_to_client_units(
-        self, lines: List[str], position: types.Position
+        self, lines: Sequence[str], position: types.Position
     ) -> types.Position:
         """
         Convert the position.character from its internal UTF-32 representation
         to client-supported UTF-[32|16|8] code units.
 
         Arguments:
-            lines (list):
+            lines (sequence):
                 The content of the document which the position refers to.
             position (Position):
                 The line and character offset in UTF-32 code units.
@@ -165,13 +164,13 @@ class PositionCodec:
             return types.Position(line=len(lines), character=0)
 
     def range_from_client_units(
-        self, lines: List[str], range: types.Range
+        self, lines: Sequence[str], range: types.Range
     ) -> types.Range:
         """
         Convert range.[start|end].character from UTF-[32|16|8] code units to UTF-32.
 
         Arguments:
-            lines (list):
+            lines (sequence):
                 The content of the document which the range refers to.
             range (Range):
                 The line and character offset in UTF-[32|16|8] code units.
@@ -186,13 +185,13 @@ class PositionCodec:
         return range_new
 
     def range_to_client_units(
-        self, lines: List[str], range: types.Range
+        self, lines: Sequence[str], range: types.Range
     ) -> types.Range:
         """
         Convert range.[start|end].character from UTF-32 to UTF-[32|16|8] code units.
 
         Arguments:
-            lines (list):
+            lines (sequence):
                 The content of the document which the range refers to.
             range (Range):
                 The line and character offset in  code units.

--- a/pygls/workspace/text_document.py
+++ b/pygls/workspace/text_document.py
@@ -21,7 +21,7 @@ import logging
 import os
 import pathlib
 import re
-from typing import List, Optional, Pattern
+from typing import Optional, Pattern, Sequence
 
 from lsprotocol import types
 
@@ -163,8 +163,8 @@ class TextDocument(object):
             self._apply_full_change(change)
 
     @property
-    def lines(self) -> List[str]:
-        return self.source.splitlines(True)
+    def lines(self) -> Sequence[str]:
+        return tuple(self.source.splitlines(True))
 
     def offset_at_position(self, client_position: types.Position) -> int:
         """Return the character offset pointed at by the given client_position."""

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -51,7 +51,7 @@ def test_document_end_of_file_edit():
     )
     doc.apply_change(change)
 
-    assert doc.lines == [
+    assert list(doc.lines) == [
         "print 'a'\n",
         "print 'b'\n",
         "o",
@@ -73,7 +73,7 @@ def test_document_full_edit():
     )
     doc.apply_change(change)
 
-    assert doc.lines == ["print a, b"]
+    assert list(doc.lines) == ["print a, b"]
 
     doc = TextDocument(
         "file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Full
@@ -87,7 +87,7 @@ def test_document_full_edit():
     )
     doc.apply_change(change)
 
-    assert doc.lines == ["print a, b"]
+    assert list(doc.lines) == ["print a, b"]
 
 
 def test_document_line_edit():
@@ -125,7 +125,7 @@ def test_document_multiline_edit():
     )
     doc.apply_change(change)
 
-    assert doc.lines == ["def hello(a, b):\n", "    print a, b\n"]
+    assert list(doc.lines) == ["def hello(a, b):\n", "    print a, b\n"]
 
     doc = TextDocument(
         "file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Incremental
@@ -139,7 +139,7 @@ def test_document_multiline_edit():
     )
     doc.apply_change(change)
 
-    assert doc.lines == ["def hello(a, b):\n", "    print a, b\n"]
+    assert list(doc.lines) == ["def hello(a, b):\n", "    print a, b\n"]
 
 
 def test_document_no_edit():
@@ -157,7 +157,7 @@ def test_document_no_edit():
     )
     doc.apply_change(change)
 
-    assert doc.lines == old
+    assert list(doc.lines) == old
 
 
 def test_document_props():


### PR DESCRIPTION
The `PositionCodec` does not need a mutable sequence as it only does read-only operations. Additionally, `TextDocument.lines` can now return an immutable list (using tuple here for simplicity), which will enable `pygls` to cache the `lines` attribute later internally.

The caching is not done in this commit as it would require us to figure out the cache invalidation rules, which will be after this has been accepted.

## Description (e.g. "Related to ...", etc.)

See #551

## Code review checklist (for code reviewer to complete)

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Commit messages are meaningful (see [this][commit messages] for details)
- [X] Tests have been included and/or updated, as appropriate
- [X] Docstrings have been included and/or updated, as appropriate
- [X] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
poetry install --all-extras --with dev
poetry run poe lint
```

[commit messages]: https://conventionalcommits.org/
