### PR TITLE
Update Makefile to easily switch between Python versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,10 @@
     "name": "pygls",
     // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
     "build": {
-	"dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile"
     },
     "containerEnv": {
-	"TZ": "UTC"
+        "TZ": "UTC"
     },
     // Features to add to the dev container. More info: https://containers.dev/features.
     // "features": {},
@@ -17,13 +17,12 @@
     // "postCreateCommand": "uname -a",
     // Configure tool-specific properties.
     "customizations": {
-	"vscode": {
-	    "extensions": [
-		"charliermarsh.ruff",
-		"ms-python.python",
-	    ]
-	}
-
+        "vscode": {
+            "extensions": [
+                "charliermarsh.ruff",
+                "ms-python.python"
+            ]
+        }
     }
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,12 @@ lint: | $(UV)
 
 .PHONY: test
 test: | $(UV)
-	$(UV) run --all-extras poe test
+	$(UV) run --group test --all-extras poe test
 
 .PHONY: test-pyodide
 test-pyodide: dist | $(NPM) $(UV)
-	$(UV) sync --group test
 	cd tests/pyodide && $(NPM) ci
-	$(UV) run poe test-pyodide
+	$(UV) run --group test poe test-pyodide
 
 .PHONY: pygls-playground
 pygls-playground: | $(NPM) $(UV)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PY ?= 3.13
+
 .PHONY: dist
 dist: | $(UV)
 	git describe --tags --abbrev=0
@@ -9,16 +11,16 @@ lint: | $(UV)
 
 .PHONY: test
 test: | $(UV)
-	$(UV) run --group test --all-extras poe test
+	$(UV) run --managed-python --python $(PY) --group test --all-extras poe test
 
 .PHONY: test-pyodide
 test-pyodide: dist | $(NPM) $(UV)
 	cd tests/pyodide && $(NPM) ci
-	$(UV) run --group test poe test-pyodide
+	$(UV) run --managed-python --python $(PY) --group test poe test-pyodide
 
 .PHONY: pygls-playground
 pygls-playground: | $(NPM) $(UV)
-	$(UV) sync --all-extras
+	$(UV) sync --managed-python --python $(PY) --all-extras
 	cd .vscode/extensions/pygls-playground && $(NPM) install --no-save
 	cd .vscode/extensions/pygls-playground && $(NPM) run compile
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ docs = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "e2e: tests that run a language server in a subprocess",
+]
 
 [tool.poe.tasks]
 test-pyodide = "pytest tests/e2e --lsp-runtime pyodide"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,26 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_collection_modifyitems(items):
+    """Re-order tests so that end-to-end tests are run last.
+
+    Idea taken from:
+    https://timonweb.com/django/optimizing-test-execution-running-live_server-tests-last-with-pytest
+    """
+    e2e_tests = []
+    other_tests = []
+
+    for item in items:
+        if "get_client_for" in getattr(item, "fixturenames", ()):
+            item.add_marker("e2e")
+            e2e_tests.append(item)
+        else:
+            other_tests.append(item)
+
+    # Modify the items list to run end-to-end tests last
+    items[:] = other_tests + e2e_tests
+
+
 @pytest.fixture(scope="session")
 def runtime(request):
     """This fixture is the source of truth as to which environment we should run the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,12 @@ def pytest_report_header(config: pytest.Config):
     runtime = config.getoption("lsp_runtime")
     transport = config.getoption("lsp_transport")
 
-    return [f"pygls: {runtime=}, {transport=}"]
+    try:
+        gil_enabled = "enabled" if sys._is_gil_enabled() else "disabled"
+    except AttributeError:
+        gil_enabled = "enabled"
+
+    return [f"pygls: {runtime=}, {transport=}", f"GIL: {gil_enabled}"]
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Building on #561, now that we're using `uv` directly for everything we're not only able to simply the Makefile greatly, but it's now trivial to switch between Python versions.

By default, the Makefile will use 3.13
```
$ make test
/home/alex/.local/bin/uv run --managed-python --python 3.13 --group test --all-extras poe test
Poe => pytest --cov
=========================================================== test session starts ===========================================================
platform linux -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0

```
But by setting the `PY` variable when running make, you easily test against a different version, say 3.9
```
$ PY=3.9 make test
/home/alex/.local/bin/uv run --managed-python --python 3.9 --group test --all-extras poe test
Using CPython 3.9.23
Removed virtual environment at: .venv
Creating virtual environment at: .venv
Installed 31 packages in 41ms
Poe => pytest --cov
=========================================================== test session starts ===========================================================
platform linux -- Python 3.9.23, pytest-8.4.1, pluggy-1.6.0
```

And since `uv` supports it, it's now trivial to start playing around with running `pygls` with a [free-threaded](https://py-free-threading.github.io/) Python build!

```
PY=3.13t make test     # <- note the `t` in the Python version!
```
For the most part, free-threaded Python appears to "just work", however, it's probably not quite ready to add to CI as there is at least one websocket test that hangs the test suite. I'm also not sure if enough of our test suite really exercises threading all that much?...

Thanks to [this code snippet](https://py-free-threading.github.io/running-gil-disabled/#at-runtime) I have updated the pytest header to indicate if the test suite is running with or without the GIL.
```
❯ PY=3.13t make test
/home/alex/.local/bin/uv run --managed-python --python 3.13t --group test --all-extras poe test
Poe => pytest --cov
=========================================================== test session starts ===========================================================
platform linux -- Python 3.13.0, pytest-8.4.1, pluggy-1.6.0
...
GIL: disabled
```  

Finally, I came across [this article](https://timonweb.com/django/optimizing-test-execution-running-live_server-tests-last-with-pytest/?featured_on=pythonbytes) the other day and thought it was a great idea, so using it as a guide I've tweaked the test suite so that all of our slow (i.e. end-to-end) tests now run last.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
