### PR TITLE
feat: add logic and tests for position at offset

### DIFF
--- a/pygls/workspace/text_document.py
+++ b/pygls/workspace/text_document.py
@@ -61,7 +61,9 @@ class TextDocument(object):
         self._source = source
 
         self._is_sync_kind_full = sync_kind == types.TextDocumentSyncKind.Full
-        self._is_sync_kind_incremental = sync_kind == types.TextDocumentSyncKind.Incremental
+        self._is_sync_kind_incremental = (
+            sync_kind == types.TextDocumentSyncKind.Incremental
+        )
         self._is_sync_kind_none = sync_kind == types.TextDocumentSyncKind.None_
 
         self._position_codec = position_codec if position_codec else PositionCodec()
@@ -75,7 +77,9 @@ class TextDocument(object):
     def position_codec(self) -> PositionCodec:
         return self._position_codec
 
-    def _apply_incremental_change(self, change: types.TextDocumentContentChangePartial) -> None:
+    def _apply_incremental_change(
+        self, change: types.TextDocumentContentChangePartial
+    ) -> None:
         """Apply an ``Incremental`` text change to the document"""
         lines = self.lines
         text = change.text
@@ -168,9 +172,13 @@ class TextDocument(object):
     def offset_at_position(self, client_position: types.Position) -> int:
         """Return the character offset pointed at by the given client_position."""
         lines = self.lines
-        server_position = self._position_codec.position_from_client_units(lines, client_position)
+        server_position = self._position_codec.position_from_client_units(
+            lines, client_position
+        )
         row, col = server_position.line, server_position.character
-        return col + sum(self._position_codec.client_num_units(line) for line in lines[:row])
+        return col + sum(
+            self._position_codec.client_num_units(line) for line in lines[:row]
+        )
 
     @property
     def source(self) -> str:
@@ -206,7 +214,9 @@ class TextDocument(object):
         return offset
 
     @staticmethod
-    def _compute_line_offsets(text: str, is_at_line_start: bool, text_offset: int = 0) -> List[int]:
+    def _compute_line_offsets(
+        text: str, is_at_line_start: bool, text_offset: int = 0
+    ) -> List[int]:
         result: List[int] = [text_offset] if is_at_line_start else []
         i = 0
         while i < len(text):
@@ -257,7 +267,9 @@ class TextDocument(object):
         if client_position.line >= len(lines):
             return ""
 
-        server_position = self._position_codec.position_from_client_units(lines, client_position)
+        server_position = self._position_codec.position_from_client_units(
+            lines, client_position
+        )
         row, col = server_position.line, server_position.character
         line = lines[row]
         # Split word in two

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -60,7 +60,9 @@ def test_document_end_of_file_edit():
 
 def test_document_full_edit():
     old = ["def hello(a, b):\n", "    print a\n", "    print b\n"]
-    doc = TextDocument("file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Full)
+    doc = TextDocument(
+        "file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Full
+    )
     change = types.TextDocumentContentChangePartial(
         range=types.Range(
             start=types.Position(line=1, character=4),
@@ -73,7 +75,9 @@ def test_document_full_edit():
 
     assert list(doc.lines) == ["print a, b"]
 
-    doc = TextDocument("file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Full)
+    doc = TextDocument(
+        "file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Full
+    )
     change = types.TextDocumentContentChangePartial(
         range=types.Range(
             start=types.Position(line=0, character=0),
@@ -108,7 +112,9 @@ def test_document_lines():
 
 def test_document_multiline_edit():
     old = ["def hello(a, b):\n", "    print a\n", "    print b\n"]
-    doc = TextDocument("file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Incremental)
+    doc = TextDocument(
+        "file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Incremental
+    )
     change = types.TextDocumentContentChangePartial(
         range=types.Range(
             start=types.Position(line=1, character=4),
@@ -121,7 +127,9 @@ def test_document_multiline_edit():
 
     assert list(doc.lines) == ["def hello(a, b):\n", "    print a, b\n"]
 
-    doc = TextDocument("file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Incremental)
+    doc = TextDocument(
+        "file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.Incremental
+    )
     change = types.TextDocumentContentChangePartial(
         range=types.Range(
             start=types.Position(line=1, character=4),
@@ -136,7 +144,9 @@ def test_document_multiline_edit():
 
 def test_document_no_edit():
     old = ["def hello(a, b):\n", "    print a\n", "    print b\n"]
-    doc = TextDocument("file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.None_)
+    doc = TextDocument(
+        "file:///uri", "".join(old), sync_kind=types.TextDocumentSyncKind.None_
+    )
     change = types.TextDocumentContentChangePartial(
         range=types.Range(
             start=types.Position(line=1, character=4),
@@ -165,65 +175,65 @@ def test_document_source_unicode():
 
 def test_position_from_utf16():
     codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
-    assert codec.position_from_client_units(['x="😋"'], types.Position(line=0, character=3)) == types.Position(
-        line=0, character=3
-    )
-    assert codec.position_from_client_units(['x="😋"'], types.Position(line=0, character=5)) == types.Position(
-        line=0, character=4
-    )
+    assert codec.position_from_client_units(
+        ['x="😋"'], types.Position(line=0, character=3)
+    ) == types.Position(line=0, character=3)
+    assert codec.position_from_client_units(
+        ['x="😋"'], types.Position(line=0, character=5)
+    ) == types.Position(line=0, character=4)
 
 
 def test_position_from_utf32():
     codec = PositionCodec(encoding=types.PositionEncodingKind.Utf32)
-    assert codec.position_from_client_units(['x="😋"'], types.Position(line=0, character=3)) == types.Position(
-        line=0, character=3
-    )
-    assert codec.position_from_client_units(['x="😋"'], types.Position(line=0, character=4)) == types.Position(
-        line=0, character=4
-    )
+    assert codec.position_from_client_units(
+        ['x="😋"'], types.Position(line=0, character=3)
+    ) == types.Position(line=0, character=3)
+    assert codec.position_from_client_units(
+        ['x="😋"'], types.Position(line=0, character=4)
+    ) == types.Position(line=0, character=4)
 
 
 def test_position_from_utf8():
     codec = PositionCodec(encoding=types.PositionEncodingKind.Utf8)
-    assert codec.position_from_client_units(['x="😋"'], types.Position(line=0, character=3)) == types.Position(
-        line=0, character=3
-    )
-    assert codec.position_from_client_units(['x="😋"'], types.Position(line=0, character=7)) == types.Position(
-        line=0, character=4
-    )
+    assert codec.position_from_client_units(
+        ['x="😋"'], types.Position(line=0, character=3)
+    ) == types.Position(line=0, character=3)
+    assert codec.position_from_client_units(
+        ['x="😋"'], types.Position(line=0, character=7)
+    ) == types.Position(line=0, character=4)
 
 
 def test_position_to_utf16():
     codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
-    assert codec.position_to_client_units(['x="😋"'], types.Position(line=0, character=3)) == types.Position(
-        line=0, character=3
-    )
+    assert codec.position_to_client_units(
+        ['x="😋"'], types.Position(line=0, character=3)
+    ) == types.Position(line=0, character=3)
 
-    assert codec.position_to_client_units(['x="😋"'], types.Position(line=0, character=4)) == types.Position(
-        line=0, character=5
-    )
+    assert codec.position_to_client_units(
+        ['x="😋"'], types.Position(line=0, character=4)
+    ) == types.Position(line=0, character=5)
 
 
 def test_position_to_utf32():
     codec = PositionCodec(encoding=types.PositionEncodingKind.Utf32)
-    assert codec.position_to_client_units(['x="😋"'], types.Position(line=0, character=3)) == types.Position(
-        line=0, character=3
-    )
+    assert codec.position_to_client_units(
+        ['x="😋"'], types.Position(line=0, character=3)
+    ) == types.Position(line=0, character=3)
 
-    assert codec.position_to_client_units(['x="😋"'], types.Position(line=0, character=4)) == types.Position(
-        line=0, character=4
-    )
+    assert codec.position_to_client_units(
+        ['x="😋"'], types.Position(line=0, character=4)
+    ) == types.Position(line=0, character=4)
 
 
 def test_position_to_utf8():
     codec = PositionCodec(encoding=types.PositionEncodingKind.Utf8)
-    assert codec.position_to_client_units(['x="😋"'], types.Position(line=0, character=3)) == types.Position(
-        line=0, character=3
-    )
+    assert codec.position_to_client_units(
+        ['x="😋"'], types.Position(line=0, character=3)
+    ) == types.Position(line=0, character=3)
 
-    assert codec.position_to_client_units(['x="😋"'], types.Position(line=0, character=4)) == types.Position(
-        line=0, character=6
-    )
+    assert codec.position_to_client_units(
+        ['x="😋"'], types.Position(line=0, character=4)
+    ) == types.Position(line=0, character=6)
 
 
 def test_range_from_utf16():
@@ -343,44 +353,44 @@ def test_position_at_offset_utf8():
 def test_utf16_to_utf32_position_cast():
     codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
     lines = ["", "😋😋", ""]
-    assert codec.position_from_client_units(lines, types.Position(line=0, character=0)) == types.Position(
-        line=0, character=0
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=0, character=1)) == types.Position(
-        line=0, character=0
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=1, character=0)) == types.Position(
-        line=1, character=0
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=1, character=2)) == types.Position(
-        line=1, character=1
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=1, character=3)) == types.Position(
-        line=1, character=2
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=1, character=4)) == types.Position(
-        line=1, character=2
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=1, character=100)) == types.Position(
-        line=1, character=2
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=3, character=0)) == types.Position(
-        line=2, character=0
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=4, character=10)) == types.Position(
-        line=2, character=0
-    )
+    assert codec.position_from_client_units(
+        lines, types.Position(line=0, character=0)
+    ) == types.Position(line=0, character=0)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=0, character=1)
+    ) == types.Position(line=0, character=0)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=1, character=0)
+    ) == types.Position(line=1, character=0)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=1, character=2)
+    ) == types.Position(line=1, character=1)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=1, character=3)
+    ) == types.Position(line=1, character=2)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=1, character=4)
+    ) == types.Position(line=1, character=2)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=1, character=100)
+    ) == types.Position(line=1, character=2)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=3, character=0)
+    ) == types.Position(line=2, character=0)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=4, character=10)
+    ) == types.Position(line=2, character=0)
 
 
 def test_position_for_line_endings():
     codec = PositionCodec(encoding=types.PositionEncodingKind.Utf16)
     lines = ["x\r\n", "y\n"]
-    assert codec.position_from_client_units(lines, types.Position(line=0, character=10)) == types.Position(
-        line=0, character=1
-    )
-    assert codec.position_from_client_units(lines, types.Position(line=1, character=10)) == types.Position(
-        line=1, character=1
-    )
+    assert codec.position_from_client_units(
+        lines, types.Position(line=0, character=10)
+    ) == types.Position(line=0, character=1)
+    assert codec.position_from_client_units(
+        lines, types.Position(line=1, character=10)
+    ) == types.Position(line=1, character=1)
 
 
 def test_word_at_position():


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

A `position_at_offset` method is added to `TextDocument`, inspired by a nice work [here](https://github.com/microsoft/vscode-languageserver-node/blob/df56e720c01c6e2d7873733807418f6ce33187ad/textDocument/src/main.ts#L281).
Related tests are also implemented.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
