### PR TITLE
Fix UTF-8 position encoding

### DIFF
--- a/pygls/workspace/position_codec.py
+++ b/pygls/workspace/position_codec.py
@@ -33,6 +33,9 @@ class PositionCodec:
     ):
         self.encoding = encoding
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__}, encoding {self.encoding}>"
+
     @classmethod
     def is_char_beyond_multilingual_plane(cls, char: str) -> bool:
         return ord(char) > 0xFFFF

--- a/pygls/workspace/position_codec.py
+++ b/pygls/workspace/position_codec.py
@@ -133,18 +133,13 @@ class PositionCodec:
                 break
 
             _current_char = _line[utf32_index]
-            _is_double_width = PositionCodec.is_char_beyond_multilingual_plane(
-                _current_char
-            )
-            if _is_double_width:
-                if self.encoding == types.PositionEncodingKind.Utf32:
-                    _client_index += 1
-                if self.encoding == types.PositionEncodingKind.Utf8:
-                    _client_index += 4
-                _client_index += 2
+            if self.encoding == types.PositionEncodingKind.Utf8:
+                _client_index += self.utf8_bytes(_current_char)
+            elif self.encoding == types.PositionEncodingKind.Utf16:
+                _client_index += (
+                    2 if self.is_char_beyond_multilingual_plane(_current_char) else 1
+                )
             else:
-                if self.encoding == types.PositionEncodingKind.Utf8 and ord(_current_char) > 127:
-                    _client_index += 1
                 _client_index += 1
             utf32_index += 1
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -292,7 +292,7 @@ def test_position_to_utf8():
 
     assert codec.position_to_client_units(
         ['x="😋"'], types.Position(line=0, character=4)
-    ) == types.Position(line=0, character=6)
+    ) == types.Position(line=0, character=7)
 
 
 def test_range_from_utf16():
@@ -375,7 +375,7 @@ def test_offset_at_position_utf8():
         position_codec=PositionCodec(encoding=types.PositionEncodingKind.Utf8),
     )
     assert doc.offset_at_position(types.Position(line=0, character=8)) == 8
-    assert doc.offset_at_position(types.Position(line=5, character=0)) == 41
+    assert doc.offset_at_position(types.Position(line=5, character=0)) == 42
 
 
 def test_utf16_to_utf32_position_cast():


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

`didChange` events coming from a client which prefers UTF-8 position encoding (Helix in my case) and includes multi-byte codepoints previously resulted in inconsistency between the client's view of the document and a pygls-based server's view of it as maintained by the `LanguageServerProtocol.lsp_text_document__did_change` -> `Workspace.update_text_document` -> `TextDocument.apply_change` -> `TextDocument._apply_incremental_change`.

For example, opening a document with the contents `öbc` and inserting an `a` to make it into `öabc` would result in pygls thinking the contents are `öbac`.

This PR introduces tests that show the issue, fixes them, and adjusts some incorrect tests that are broken by the fix.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
