### PR TITLE
fix: Handle a special case of BrokenPipeError exception 

### DIFF
--- a/pygls/protocol/json_rpc.py
+++ b/pygls/protocol/json_rpc.py
@@ -542,6 +542,9 @@ class JsonRPCProtocol:
             if inspect.isawaitable(res):
                 asyncio.ensure_future(res)
 
+        except BrokenPipeError as e:
+            logger.exception("Error sending data. BrokenPipeError", exc_info=True)
+            raise
         except Exception as error:
             logger.exception("Error sending data", exc_info=True)
             self._server._report_server_error(error, JsonRpcInternalError)

--- a/pygls/protocol/json_rpc.py
+++ b/pygls/protocol/json_rpc.py
@@ -542,7 +542,7 @@ class JsonRPCProtocol:
             if inspect.isawaitable(res):
                 asyncio.ensure_future(res)
 
-        except BrokenPipeError as e:
+        except BrokenPipeError:
             logger.exception("Error sending data. BrokenPipeError", exc_info=True)
             raise
         except Exception as error:


### PR DESCRIPTION
`_send_data` method catches any exception and calls `report_server_error` method that tries to notify client. But the connection to the client is lost. It cause the infinite exception loop.


_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly



[commit messages]: https://conventionalcommits.org/
