### PR TITLE
fix: missing inline completion provider server capability

### DIFF
--- a/pygls/capabilities.py
+++ b/pygls/capabilities.py
@@ -427,6 +427,14 @@ class ServerCapabilitiesBuilder:
             self.server_cap.inline_value_provider = value
         return self
 
+    def _with_inline_completion_provider(self):
+        value = self._provider_options(
+            types.TEXT_DOCUMENT_INLINE_COMPLETION, default=None
+        )
+        if value is not None:
+            self.server_cap.inline_completion_provider = value
+        return self
+
     def _build(self):
         return self.server_cap
 
@@ -465,5 +473,6 @@ class ServerCapabilitiesBuilder:
             ._with_workspace_capabilities()
             ._with_diagnostic_provider()
             ._with_inline_value_provider()
+            ._with_inline_completion_provider()
             ._build()
         )

--- a/tests/test_feature_manager.py
+++ b/tests/test_feature_manager.py
@@ -684,6 +684,22 @@ def server_capabilities(**kwargs):
                 ),
             ),
         ),
+        (
+            lsp.TEXT_DOCUMENT_INLINE_COMPLETION,
+            None,
+            lsp.ClientCapabilities(),
+            server_capabilities(
+                inline_completion_provider=None,
+            ),
+        ),
+        (
+            lsp.TEXT_DOCUMENT_INLINE_COMPLETION,
+            lsp.InlineCompletionOptions(),
+            lsp.ClientCapabilities(),
+            server_capabilities(
+                inline_completion_provider=lsp.InlineCompletionOptions(),
+            ),
+        ),
     ],
 )
 def test_register_feature(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

The textDocument/InlineCompletion feature was not being properly announced as a server capability.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
