### PR TITLE
docs: use correct lsprotocol version

### DIFF
--- a/docs/source/pygls/howto/migrate-to-v2.rst
+++ b/docs/source/pygls/howto/migrate-to-v2.rst
@@ -1,7 +1,7 @@
 How To Migrate to v2.0
 ======================
 
-The highlight of the *pygls* v2 release is upgrading ``lsprotocol`` to ``v2024.x`` bringing with it support for the proposed LSP v3.18 types and methods.
+The highlight of the *pygls* v2 release is upgrading ``lsprotocol`` to ``v2025.x`` bringing with it support for the proposed LSP v3.18 types and methods.
 The new version includes standardised object names (so no more classes like ``NotebookDocumentSyncRegistrationOptionsNotebookSelectorType2CellsType``!)
 
 With the major version bump, this release also takes the opportunity to clean up the codebase by removing deprecated code and renaming a few things to try and improve overall consistency.
@@ -310,10 +310,10 @@ The helper is now accessed via ``LanguageServer.work_done_progress``
 Renamed LSP Types
 -----------------
 
-As part of the update to ``lsprotocol v2024``, the following types have been renamed.
+As part of the update to ``lsprotocol v2025``, the following types have been renamed.
 
 ===================================================================================  ==============
-**lsprotocol 2023.x**                                                                **lsprotocol 2024.x**
+**lsprotocol 2023.x**                                                                **lsprotocol 2025.x**
 ===================================================================================  ==============
 ``CancelRequestNotification``                                                        ``CancelNotification``
 ``ClientRegisterCapabilityRequest``                                                  ``RegistrationRequest``


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

v2 shipped with lsprotocol v2025, not v2024

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/