### PR TITLE
docs: describe arguments unpacking for server commands in v2

### DIFF
--- a/docs/source/pygls/howto/migrate-to-v2.rst
+++ b/docs/source/pygls/howto/migrate-to-v2.rst
@@ -75,12 +75,14 @@ To send custom notifications in v2, use the ``notify`` method on the underlying 
 See :ref:`howto-send-custom-messages` for more details
 
 
-Server commands can now use type annotations
---------------------------------------------
+Server commands are now called with individual arguments and can use type annotations
+-------------------------------------------------------------------------------------
+
+Instead of calling sever commands with a single arguments of type list containing all the command arguments, *pygls v2* now unpacks the arguments and passes them as individual parameters to the command method.
 
 *pygls* will now inspect a function's type annotations when handling ``workspace/executeCommand`` requests, automatically converting JSON values to ``attrs`` class instances, or responding with an error if appropriate.
 
-It is **not mandatory** to start using type annotations in your command definitions, but you may notice a difference in how *pygls* calls your server command methods.
+It is **not mandatory** to start using type annotations in your command definitions, but you will notice a difference in how *pygls* calls your server command methods if they take arguments.
 
 **Before**
 
@@ -88,7 +90,7 @@ It is **not mandatory** to start using type annotations in your command definiti
 
    @server.command("codeLens.evaluateSum")
    def evaluate_sum(ls: LanguageServer, args):
-       logging.info("arguments: %s", args)
+       logging.info("arguments: %s", args)  # here args is a list of dict
 
        arguments = args[0]
        document = ls.workspace.get_text_document(arguments["uri"])
@@ -142,7 +144,7 @@ It is **not mandatory** to start using type annotations in your command definiti
 
     @server.command("codeLens.evaluateSum")
     def evaluate_sum(ls: LanguageServer, args: EvaluateSumArgs):
-        logging.info("arguments: %s", args)
+        logging.info("arguments: %s", args)  # here args is an instance of EvaluateSumArgs
 
         document = ls.workspace.get_text_document(args.uri)
         line = document.lines[args.line]


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

With the new way of calling commands with arguments from type annotations, another significant change is that the command is now called with individual arguments and no longer a list of arguments.

The `calculate_pow` from `examples/servers/commands.py` before https://github.com/openlawlibrary/pygls/commit/87e1033fe5276e265237948aada10b77857a503b would have been something like this (it did not exist yet before this change). 

```py
@server.command("calculate.pow")
def calculate_pow(args):
    """pygls 1.x version: the list of arguments is passed as a single argument."""
    x, n = args
    logging.info("args: %r, x: %r, n: %r", args, x, n)
    return x**n
```

it is now https://github.com/openlawlibrary/pygls/blob/87e1033fe5276e265237948aada10b77857a503b/examples/servers/commands.py#L65-L69 

when called like this from client like this:

```js
await vscode.commands.executeCommand("calculate.pow", 2, 8)
```

the old version received arguments as a list ( `[2, 8]` ), see the logged message when running:

```
2025-10-19 20:17:01.877 [info] executing command: 'calculate.pow'
2025-10-19 20:17:01.885 [info] args: [2, 8], x: 2, n: 8

2025-10-19 20:17:01.885 [info] Sending data: {"id": 1, "jsonrpc": "2.0", "result": 256}
```

I believe the migration doc could be a bit more explicit regarding this change, it was not obvious for me when upgrading to pygls2 ( for reference, I missed this https://github.com/perrinjerome/vscode-zc-buildout/pull/63 )

I'm submitting here a PR to the docs to try to describe this a bit more.


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
