### PR TITLE
Fix spelling mistakes in v2 migration documentation

### DIFF
--- a/docs/source/pygls/howto/migrate-to-v2.rst
+++ b/docs/source/pygls/howto/migrate-to-v2.rst
@@ -51,10 +51,10 @@ The following methods and functions have been deprecated for some time and have 
 ``pygls.workspace.range_from_utf16``                ``TextDocument.position_codec.range_from_client_units`` or ``Workspace.position_codec.range_from_client_units``
 ``pygls.workspace.range_to_utf16``                  ``TextDocument.position_codec.range_to_client_units`` or ``Workspace.position_codec.range_to_client_units``
 ``Workspace.documents``                             ``Workspace.text_documents``
-``Worspace.get_document``                           ``Workspace.get_text_document``
-``Worspace.put_document``                           ``Workspace.put_text_document``
-``Worspace.remove_document``                        ``Workspace.remove_text_document``
-``Worspace.update_document``                        ``Workspace.update_text_document``
+``Workspace.get_document``                           ``Workspace.get_text_document``
+``Workspace.put_document``                           ``Workspace.put_text_document``
+``Workspace.remove_document``                        ``Workspace.remove_text_document``
+``Workspace.update_document``                        ``Workspace.update_text_document``
 ==================================================  ==============
 
 Sending Custom Notifications


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Workspace misspelt as Worspace in v2 migration documentation.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
