### PR TITLE
fix: prevent exception handling for cancelled futures in JsonRPCProtocol

### DIFF
--- a/pygls/protocol/json_rpc.py
+++ b/pygls/protocol/json_rpc.py
@@ -321,7 +321,7 @@ class JsonRPCProtocol:
 
         Used when handling notification messages
         """
-        if (exc := future.exception()) is not None:
+        if not future.cancelled() and (exc := future.exception()) is not None:
             try:
                 raise exc
             except Exception:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Fixes #587. In `JsonRPCProtocol._check_handler_result()`, we should check whether the future is cancelled before determining if there was an exception.

I tried to create a test in `tests/lsp/test_errors.py` that would fail before this fix and pass after this fix (based on [my reproducible example](https://github.com/openlawlibrary/pygls/issues/587#issue-3791204276)) but was unsuccessful. The required setup is a little complex for this testing infrastructure. Since we don't test the "cancelled" scenario in other tests, I think this is okay.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
