### PR TITLE
chore(readthedocs): build offline formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@
 # Required
 version: 2
 
+# Build all formats
+formats: all
+
 # Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

I wanted to download the pygls documentation for my ereader to read some parts of it while away from computer and internet, but downloads aren’t currently made and made available.

This makes Read the Docs build epub, pdf, and other supported formats and provide them as download options for users to be able to download for easy and offline reference.

See also https://docs.readthedocs.com/platform/stable/downloadable-documentation.html and https://docs.readthedocs.com/platform/stable/guides/enable-offline-formats.html

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
