### PR TITLE
Update action versions and test on Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,30 @@ jobs:
           cancel_others: "true"
           skip_after_successful_duplicate: "false"
 
-  test:
+  build:
     needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5  # v3.0.1
+        id: baipp
+
+    outputs:
+      python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+
+  test:
+    needs: [pre_job, build]
     if: needs.pre_job.outputs.should_skip != 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJson(needs.build.outputs.python-versions) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -78,8 +94,9 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: build-artifacts
+          name: 'Packages'
           path: 'dist'
+
 
       - name: Install Dependencies
         run: |
@@ -111,31 +128,3 @@ jobs:
 
       - name: Run lints
         run: uv run --all-extras poe lint
-
-  build:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  #v10.0.1
-        with:
-          version: "0.12.10"
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Build packages (sdist and wheel)
-        run: |
-          git describe --tags --abbrev=0
-          uv build
-
-      - name: Upload builds
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: build-artifacts
-          path: "dist/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -19,7 +21,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: "outdated_runs"
           cancel_others: "true"
@@ -35,11 +37,15 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          version: "0.7.16"
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  #v10.0.1
+        with:
+          version: "0.12.10"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -52,22 +58,25 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          node-version: 20.x
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: 'tests/pyodide/package-lock.json'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  #v10.0.1
         with:
-          version: "0.7.16"
+          version: "0.12.10"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-artifacts
           path: 'dist'
@@ -88,15 +97,18 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  #v10.0.1
         with:
-          version: "0.7.16"
+          version: "0.12.10"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+
       - name: Run lints
         run: uv run --all-extras poe lint
 
@@ -105,21 +117,25 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  #v10.0.1
         with:
-          version: "0.7.16"
+          version: "0.12.10"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+
       - name: Build packages (sdist and wheel)
         run: |
           git describe --tags --abbrev=0
           uv build
+
       - name: Upload builds
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-artifacts
           path: "dist/*"

--- a/.github/workflows/json-extension.yml
+++ b/.github/workflows/json-extension.yml
@@ -9,6 +9,8 @@ on:
     branches:
     - main
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,15 +21,17 @@ jobs:
         working-directory: .vscode/extensions/pygls-playground
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.x"
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: 'npm'
           cache-dependency-path: '.vscode/extensions/pygls-playground/package-lock.json'
 
@@ -65,7 +69,7 @@ jobs:
           npx vsce ls | grep out/extension.js
 
       - name: Upload VSIX
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: pygls-playground-vsix
           # The path must be rooted from the directory GitHub Actions starts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,33 +5,34 @@ on:
     types: [published]
 
 jobs:
-  relase:
+  release:
     name: "🚀 Release 🚢"
     runs-on: ubuntu-latest
     steps:
+
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ssh-key: ${{secrets.CI_RELEASE_DEPLOY_KEY}}
           fetch-depth: 0
-      - name: Use Python "3.10"
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
-        with:
-          python-version: "3.10"
+          persist-credentials: true  # needed to push commits to main
+
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  #v10.0.1
         with:
-          version: "0.7.16"
+          version: "0.12.10"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+
       - name: Generate the latest changelog
-        uses: orhun/git-cliff-action@4a4a951bc43fafe41cd2348d181853f52356bee7 # v4.4.2
+        uses: orhun/git-cliff-action@3d96a18cc4ec17e9dc69ddcc424ccafaf1f78ce2 # v4.9.0
         id: git-cliff
         with:
           config: cliff.toml
           args: --verbose --latest
         env:
           OUTPUT: git-cliff-changes.tmp.md
+
       - name: Update the changelog
         run: |
           git checkout main
@@ -41,6 +42,7 @@ jobs:
           git add CHANGELOG.md
           git commit -m "chore: update CHANGELOG.md"
           git push
+
       - name: Update CONTRIBUTORS.md
         run: |
           git checkout main
@@ -50,6 +52,7 @@ jobs:
             git commit -m "chore: update CONTRIBUTORS.md"
             git push
           fi
+
       - name: Release
         run: |
           uv build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  #v10.0.1
         with:
           version: "0.12.10"
-          enable-cache: true
+          enable-cache: false
           cache-dependency-glob: "uv.lock"
 
       - name: Generate the latest changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 dependencies = [
     "attrs>=24.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,17 @@ maintainers = [
 ]
 readme = "README.md"
 requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
 dependencies = [
     "attrs>=24.3.0",
     "cattrs>=23.1.2",


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- This updates all the action dependencies, superseding #624 
- This also tweaks the `ci.build` job to use [hynek/build-and-inspect-python-package/](https://github.com/hynek/build-and-inspect-python-package/) to build the wheel
  - The main benefit of this action in my mind is that it also exports the supported Python versions as an output, allowing us to define our ci build matrix in terms of pygls' packaging metadata
- Adds the relevant metadata to `pyproject.toml` to declare the versions of Python we support (including the upcoming 3.15)

Side question: Are we happy with dropping support for 3.9 and potentially 3.10? Both will be EOL as of the release of 3.15. 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated linters

You can run the lints that are run on CI locally with:
```sh
uv run --all-extras poe lint
```

[commit messages]: https://conventionalcommits.org/
